### PR TITLE
Add bin key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "bugs": {
     "url": "https://github.com/Nihilus118/vscode-perl-debug"
   },
+  "bin": "out/debugAdapter.js",
   "scripts": {
     "test": "jest",
     "compile": "tsc -p ./",


### PR DESCRIPTION
Makes `npm pack` detect files in `out/` as part of the package. Eases installation of this package by other package managers, for other editors. See #6.