### PR TITLE
Release/2.0.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,12 +42,37 @@
 				"${workspaceFolder}/out/**/*.js"
 			],
 			"preLaunchTask": "npm: compile"
+		},
+		{
+			"type": "perl",
+			"request": "launch",
+			"name": "Perl Debug",
+			"program": "${workspaceFolder}/${relativeFile}",
+			"perlExecutable": "C:\\berrybrew\\instance\\5.38.0_64\\perl\\bin\\perl.exe",
+			"args": [
+				"arg1", // $ARGV[0]
+				"arg2" // $ARGV[1]
+			],
+		},
+		{
+			"type": "perl",
+			"request": "launch",
+			"name": "Perl Debug Fork Socket Manual",
+			"program": "${workspaceFolder}/src/tests/data/fork_socket_manual.pl",
+			"cwd": "${workspaceFolder}/src/tests/data",
+			"stopOnEntry": true,
+			"transport": "socket",
+			"trace": true,
+			"perlExecutable": "C:\\berrybrew\\instance\\5.38.0_64\\perl\\bin\\perl.exe"
 		}
 	],
 	"compounds": [
 		{
 			"name": "Extension + Server",
-			"configurations": [ "Extension", "Server" ]
+			"configurations": [
+				"Extension",
+				"Server"
+			]
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Improve startup breakpoint handling for breakpoints selected before launch
 * Improve multi-file prelaunch breakpoint behavior by deferring non-main-script breakpoints until source load
 * Improve Windows path error handling when changing file context in perl5db
+* Add lazy loading for nested variables in the debug view (expand-on-demand)
+* Add chunked display for large arrays/hashes using maxArrayElements and maxHashElements as chunk size
 * Add regression tests for prelaunch breakpoints, stop-on-entry ordering, transport behavior, and perl5db path-error handling
 
 ## 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 * Improve Windows path error handling when changing file context in perl5db
 * Add lazy loading for nested variables in the debug view (expand-on-demand)
 * Add chunked display for large arrays/hashes using maxArrayElements and maxHashElements as chunk size
+* Keep large array/hash chunk references stable and expandable for very large collections
+* Improve hash chunk ordering by using numeric-aware key sorting when keys are numeric
+* Improve setVariable reliability for nested and chunked variables by reusing/reloading evaluateName expressions
+* Fix stale variable values after setVariable by refreshing cached container state
+* Add a safety cap to variable dump retries to prevent unbounded continue loops on malformed debugger output
+* Improve shutdown reliability by terminating detached perl process trees to avoid dangling runtimes after repeated sessions
 * Add regression tests for prelaunch breakpoints, stop-on-entry ordering, transport behavior, and perl5db path-error handling
 
 ## 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0
+* Add socket transport support for perl5db and child fork runtimes
+* Make socket transport the default debugger transport
+* Keep stdio transport available as an explicit launch option
+* Restrict unsupported fork-session termination guard to stdio transport
+* Improve startup breakpoint handling for breakpoints selected before launch
+* Improve multi-file prelaunch breakpoint behavior by deferring non-main-script breakpoints until source load
+* Improve Windows path error handling when changing file context in perl5db
+* Add regression tests for prelaunch breakpoints, stop-on-entry ordering, transport behavior, and perl5db path-error handling
+
 ## 1.0.0
 * Step in, step out, step over, restart, terminate
 * Set breakpoints in any script or module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-debug-adapter",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-debug-adapter",
-      "version": "1.0.12",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,28 +33,14 @@
         "vscode": "^1.94.0"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -63,9 +49,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -73,22 +59,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
-      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helpers": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -114,16 +100,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.1",
-        "@babel/types": "^7.27.1",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -131,13 +117,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -157,30 +143,40 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
-      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -190,9 +186,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -210,9 +206,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -230,27 +226,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
-      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -315,13 +311,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -357,13 +353,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -483,13 +479,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -499,58 +495,48 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -989,9 +975,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1008,9 +994,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1018,24 +1004,31 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1044,9 +1037,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1057,19 +1050,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
-      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1080,20 +1076,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -1103,10 +1099,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1125,9 +1128,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1138,9 +1141,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
-      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1151,9 +1154,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1161,13 +1164,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1185,31 +1188,17 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1282,9 +1271,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1650,18 +1639,25 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1674,27 +1670,17 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1702,48 +1688,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1803,19 +1751,19 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1875,9 +1823,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1899,16 +1847,16 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.100.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
-      "integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.115.0.tgz",
+      "integrity": "sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1923,21 +1871,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
-      "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/type-utils": "8.32.1",
-        "@typescript-eslint/utils": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1947,23 +1894,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
-      "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/typescript-estree": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1973,19 +1920,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
-      "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1995,17 +1964,35 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
-      "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.32.1",
-        "@typescript-eslint/utils": "8.32.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2015,14 +2002,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
-      "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2034,20 +2021,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
-      "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2057,20 +2045,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
-      "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/typescript-estree": "8.32.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2080,19 +2068,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
-      "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.58.1",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2103,13 +2091,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2147,9 +2135,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2170,9 +2158,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2248,13 +2236,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2339,9 +2320,9 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2362,7 +2343,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -2383,20 +2364,39 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2433,10 +2433,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2496,9 +2497,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
       "funding": [
         {
@@ -2593,9 +2594,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2671,9 +2672,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2689,9 +2690,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2740,26 +2741,10 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.157",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
-      "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -2784,9 +2769,9 @@
       "license": "MIT"
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2858,33 +2843,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
-      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.27.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2896,7 +2880,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2919,9 +2903,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2948,10 +2932,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2960,9 +2951,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2983,9 +2974,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2996,15 +2987,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3014,9 +3005,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3041,9 +3032,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3143,36 +3134,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3186,16 +3147,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3218,29 +3169,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -3288,9 +3216,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3373,7 +3301,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3404,10 +3332,17 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3416,9 +3351,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3448,12 +3383,27 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3496,9 +3446,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3725,9 +3675,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3736,49 +3686,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jest": {
@@ -4372,9 +4279,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4569,16 +4476,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -4604,19 +4501,29 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -4633,6 +4540,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4641,9 +4555,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4833,9 +4747,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5003,27 +4917,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -5042,13 +4935,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -5105,45 +4998,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5372,10 +5230,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5384,9 +5249,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5394,6 +5259,54 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {
@@ -5417,9 +5330,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5430,20 +5343,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
-      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -5455,11 +5367,12 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.3 <6"
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -5475,6 +5388,9 @@
           "optional": true
         },
         "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
           "optional": true
         }
       }
@@ -5529,9 +5445,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5540,6 +5456,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -5559,9 +5489,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -5649,6 +5579,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perl-debug-adapter",
   "displayName": "Perl Debug Adapter",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "publisher": "nihilus118",
   "description": "Debug Adapter for the Perl CLI-Debugger.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "bin": "out/debugAdapter.js",
   "scripts": {
     "test": "jest",
+    "build": "npm run compile",
     "compile": "tsc -p ./",
     "lint": "eslint src --ext ts",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=node --outfile=dist/extension.js",
@@ -213,6 +214,15 @@
                   "type": "string"
                 },
                 "default": []
+              },
+              "transport": {
+                "type": "string",
+                "enum": [
+                  "stdio",
+                  "socket"
+                ],
+                "description": "Debugger transport for perl5db. `socket` is experimental and currently supports only the primary debugger session.",
+                "default": "stdio"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -221,8 +221,8 @@
                   "stdio",
                   "socket"
                 ],
-                "description": "Debugger transport for perl5db. `socket` is experimental and currently supports only the primary debugger session.",
-                "default": "stdio"
+                "description": "Debugger transport for perl5db. `socket` supports forked child runtimes and is the recommended default.",
+                "default": "socket"
               }
             }
           }

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ Forked Perl debugging requires the `socket` transport. The adapter now defaults 
 
 When explicitly using `stdio`, forked Perl debugging is still unsupported by `perl5db` (it requires a separate TTY for child debuggers). In that mode, if `perl5db` reports that it cannot create a new TTY, the session is terminated to avoid corrupted debugger state.
 
+On terminate/restart/error paths, the adapter also tears down detached Perl process trees to avoid leaving dangling interpreter sessions behind.
+
 #### launch.json examples
 
 Recommended (default): `socket` transport
@@ -53,6 +55,12 @@ Large collections are split into chunk nodes in the Variables view:
 
 * Arrays use `maxArrayElements` as chunk size (`[0..99]`, `[100..199]`, ...)
 * Hashes use `maxHashElements` as chunk size (`[keys 0..99]`, `[keys 100..199]`, ...)
+
+Chunk nodes remain expandable for very large collections.
+
+For hash chunks, numeric keys are ordered numerically (`1, 2, 10`) while non-numeric keys are ordered lexicographically.
+
+Setting variable values is supported for nested/chunked entries as well; repeated edits in the same expanded chunk now reuse/reload the correct expression context.
 
 This keeps initial variable rendering responsive while still allowing deep inspection on demand.
 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,8 @@ It should work out of the box on Linux, Windows and Mac using VS Code. It also w
 * The PadWalker module needs to be available in your environment.
 * **OPTIONAL** I recommend using this extension together with BSCANs [Perl Navigator](https://marketplace.visualstudio.com/items?itemName=bscan.perlnavigator) as it provides great language server features out of the box.
 
+Forked Perl debugging is currently not supported by this adapter. When `perl5db` reports that it cannot create a new TTY for a forked child, the session is terminated to avoid corrupted debugger state.
+
 ### Other Editors and IDEs
 
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,37 @@ It should work out of the box on Linux, Windows and Mac using VS Code. It also w
 * The PadWalker module needs to be available in your environment.
 * **OPTIONAL** I recommend using this extension together with BSCANs [Perl Navigator](https://marketplace.visualstudio.com/items?itemName=bscan.perlnavigator) as it provides great language server features out of the box.
 
-Forked Perl debugging is currently not supported by this adapter. When `perl5db` reports that it cannot create a new TTY for a forked child, the session is terminated to avoid corrupted debugger state.
+Forked Perl debugging requires the `socket` transport. The adapter now defaults to `socket` so `perl5db` can attach child debugger runtimes over TCP loopback.
+
+When explicitly using `stdio`, forked Perl debugging is still unsupported by `perl5db` (it requires a separate TTY for child debuggers). In that mode, if `perl5db` reports that it cannot create a new TTY, the session is terminated to avoid corrupted debugger state.
+
+#### launch.json examples
+
+Recommended (default): `socket` transport
+
+```json
+{
+  "type": "perl",
+  "request": "launch",
+  "name": "Perl Debug",
+  "program": "${workspaceFolder}/${relativeFile}",
+  "stopOnEntry": true,
+  "transport": "socket"
+}
+```
+
+Legacy/fallback: `stdio` transport
+
+```json
+{
+  "type": "perl",
+  "request": "launch",
+  "name": "Perl Debug (stdio)",
+  "program": "${workspaceFolder}/${relativeFile}",
+  "stopOnEntry": true,
+  "transport": "stdio"
+}
+```
 
 ### Other Editors and IDEs
 

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,31 @@ Legacy/fallback: `stdio` transport
 }
 ```
 
+#### Variable expansion and chunking
+
+Variables are loaded lazily in the debug view. Nested array/hash levels are not fetched until you expand them.
+
+Large collections are split into chunk nodes in the Variables view:
+
+* Arrays use `maxArrayElements` as chunk size (`[0..99]`, `[100..199]`, ...)
+* Hashes use `maxHashElements` as chunk size (`[keys 0..99]`, `[keys 100..199]`, ...)
+
+This keeps initial variable rendering responsive while still allowing deep inspection on demand.
+
+Example configuration:
+
+```json
+{
+  "type": "perl",
+  "request": "launch",
+  "name": "Perl Debug",
+  "program": "${workspaceFolder}/${relativeFile}",
+  "transport": "socket",
+  "maxArrayElements": 100,
+  "maxHashElements": 100
+}
+```
+
 ### Other Editors and IDEs
 
 

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -65,6 +65,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	private sortKeys: boolean = false;
 
 	private deepcopy: boolean = false;
+	private terminatedDueToUnsupportedFork = false;
 
 	constructor() {
 		super('perl-debug.txt');
@@ -104,6 +105,33 @@ export class PerlDebugSession extends LoggingDebugSession {
 		const response = await this.streamCatcher.request(command);
 		logger.log(`Response for command ${command}: ${response.join('\n')}`);
 		return response;
+	}
+
+	private handleSessionOutput(data: string, category: 'stdout' | 'stderr'): void {
+		const output = data.replace(ansiSeq, '');
+		this.logSendEvent(new OutputEvent(output, category));
+
+		if (output.includes('Forked, but do not know how to create a new TTY')) {
+			this.handleUnsupportedFork();
+		}
+	}
+
+	private handleUnsupportedFork(): void {
+		if (this.terminatedDueToUnsupportedFork) {
+			return;
+		}
+
+		this.terminatedDueToUnsupportedFork = true;
+		this.logSendEvent(new OutputEvent(
+			'Forked Perl debugging is not supported by this adapter because perl5db requires a separate TTY for child debuggers. The session has been stopped to avoid corrupted state.',
+			'important'
+		));
+
+		if (this._session && !this._session.killed) {
+			this._session.kill();
+		}
+
+		this.logSendEvent(new TerminatedEvent());
 	}
 
 	/**
@@ -291,6 +319,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArguments): Promise<void> {
+		this.terminatedDueToUnsupportedFork = false;
 
 		// reset breakpointID and clear maps
 		this.currentBreakpointID = 1;
@@ -404,9 +433,11 @@ export class PerlDebugSession extends LoggingDebugSession {
 			return;
 		});
 
-		// send the script output to the debug console
 		this._session.stdout!.on('data', (data) => {
-			this.logSendEvent(new OutputEvent(data.toString().replace(ansiSeq, ''), 'stdout'));
+			this.handleSessionOutput(data.toString(), 'stdout');
+		});
+		this._session.stderr!.on('data', (data) => {
+			this.handleSessionOutput(data.toString(), 'stderr');
 		});
 
 		await this.streamCatcher.launch(
@@ -825,9 +856,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	// Regexp for parsing the output of Data::Dumper
-	private isNamedVariable = /"?(.*)"?\s=>?\s(undef|".*"|'.*'|-?\d+|\[\]|\{\}|bless\(.*\)|sub\s\{.*\}|\\\*\{".*\"}|\\{1,2}\*.*)[,|;]$/;
+	private isNamedVariable = /"?(.*)"?\s=>?\s(undef|".*"|'.*'|-?\d+|\[\]|\{\}|bless\(.*\)|sub\s\{.*\}|\\\*\{".*\"}|\\{1,2}\*.*)[,|;]?$/;
 	private isIndexedVariable = /^(undef|".*"|'.*'|-?\d+|\[\]|\{\}|bless\(.*\)|sub\s\{.*\})[,|;]?/;
-	private isNestedHash = /"(.*)"\s=>?\s(bless\(\s)?(\[|\{)/;
+	private isNestedHash = /"(.*)"\s=>?\s(?:bless\(\s*)?(\[|\{)\s*$/;
 	private isNestedArray = /^(bless\(\s*)?(\{|\[)$/;
 	private isVarEnd = /^(\}|\]),?(\s?'(.*)'\s\))?[,|;]?/;
 	// Parse output of Data::Dumper
@@ -845,6 +876,25 @@ export class PerlDebugSession extends LoggingDebugSession {
 				varType = `${(matched[1] === '}' ? 'HASH' : 'ARRAY')}${(matched[3] ? ` ${matched[3]}` : '')}`;
 				break;
 			}
+			matched = line.match(this.isNamedVariable);
+			const nestedHash = line.match(this.isNestedHash);
+			if (nestedHash) {
+				const newVar: DebugProtocol.Variable = {
+					name: nestedHash[1],
+					value: '',
+					variablesReference: this.currentVarRef,
+					presentationHint: { kind: 'innerClass' }
+				};
+				this.parentVarsMap.set(this.currentVarRef, newVar);
+				const parsed = this.parseDumper(lines.slice(i + 1));
+				i += parsed.parsedLines;
+				newVar.value = parsed.varType;
+				newVar.type = parsed.varType;
+				newVar.namedVariables = parsed.numChildVars;
+				childVars.push(newVar);
+				continue;
+			}
+
 			matched = line.match(this.isNamedVariable);
 			if (matched) {
 				childVars.push({
@@ -893,28 +943,19 @@ export class PerlDebugSession extends LoggingDebugSession {
 				}
 				continue;
 			}
-			matched = line.match(this.isNestedHash);
-			if (matched) {
-				const newVar: DebugProtocol.Variable = {
-					name: matched[1],
-					value: '',
-					variablesReference: this.currentVarRef,
-					presentationHint: { kind: 'innerClass' }
-				};
-				this.parentVarsMap.set(this.currentVarRef, newVar);
-				const parsed = this.parseDumper(lines.slice(i + 1));
-				i += parsed.parsedLines;
-				newVar.value = parsed.varType;
-				newVar.type = parsed.varType;
-				newVar.namedVariables = parsed.numChildVars;
-				childVars.push(newVar);
-				continue;
+			if (line.trim() !== '') {
+				childVars.push({
+					name: `${childVars.length}`,
+					value: line.trim(),
+					variablesReference: 0,
+					presentationHint: { kind: 'data' },
+					type: 'SCALAR'
+				});
 			}
-			logger.error(`Unrecognized Data::Dumper line: ${line}`);
-			logger.log(`All lines in current variable scope: ${lines.join('\n')}`);
 		}
 		this.childVarsMap.set(ref, childVars);
-		return { parsedLines: i + 1, varType: varType, numChildVars: childVars.length };
+		const parsedLines = i < lines.length ? i + 1 : i;
+		return { parsedLines: parsedLines, varType: varType, numChildVars: childVars.length };
 	}
 
 	protected async setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): Promise<void> {

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -1,9 +1,12 @@
 import {
-	Breakpoint, ContinuedEvent, Handles, InitializedEvent, logger, Logger, LoggingDebugSession, OutputEvent, Scope, Source, StackFrame, StoppedEvent, TerminatedEvent, Variable
+	Breakpoint, ContinuedEvent, Handles, InitializedEvent, logger, Logger, LoggingDebugSession, OutputEvent, Scope, Source, StackFrame, StoppedEvent, TerminatedEvent, ThreadEvent, Variable
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { ChildProcess, spawn, SpawnOptions } from 'child_process';
+import * as Net from 'net';
 import { basename, dirname, join } from 'path';
+import { Readable } from 'stream';
+import { Writable } from 'stream';
 import { ansiSeq, StreamCatcher } from './streamCatcher';
 import unescapeJs from 'unescape-js';
 import * as path from 'path';
@@ -25,6 +28,7 @@ interface ILaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	sortKeys?: boolean;
 	deepcopy?: boolean;
 	wrapperCommand?: string[];
+	transport?: 'stdio' | 'socket';
 }
 
 interface IFunctionBreakpointData {
@@ -38,16 +42,35 @@ interface IBreakpointData {
 	condition: string;
 }
 
+interface IDebuggerRuntime {
+	threadId: number;
+	name: string;
+	streamCatcher: StreamCatcher;
+	isPrimary: boolean;
+	socket?: Net.Socket;
+}
+
+interface IScopeHandle {
+	scope: 'my' | 'our' | 'special';
+	threadId: number;
+}
+
 export class PerlDebugSession extends LoggingDebugSession {
 	private static threadId = 1;
-	private currentVarRef = 999;
 	private currentBreakpointID = 1;
 
-	private _variableHandles = new Handles<'my' | 'our' | 'special'>();
+	private _variableHandles = new Handles<IScopeHandle>();
 	private childVarsMap = new Map<number, Variable[]>();
 	private parentVarsMap = new Map<number, Variable>();
-	private breakpointsMap = new Map<string, IBreakpointData[]>();
-	private postponedBreakpoints = new Map<string, IBreakpointData[]>();
+	private frameThreadMap = new Map<number, number>();
+	private variableThreadMap = new Map<number, number>();
+	private threadVarRef = new Map<number, number>();
+	private frameIdSeed = 1;
+	private currentStoppedThreadId = PerlDebugSession.threadId;
+	private desiredBreakpointsMap = new Map<string, IBreakpointData[]>();
+	private desiredPostponedBreakpointsMap = new Map<string, IBreakpointData[]>();
+	private runtimeBreakpointsMap = new Map<number, Map<string, IBreakpointData[]>>();
+	private runtimePostponedBreakpointsMap = new Map<number, Map<string, IBreakpointData[]>>();
 	private funcBps: IFunctionBreakpointData[] = [];
 	private cwd = '';
 	private escapeSpecialChars = false;
@@ -56,6 +79,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	private _session!: ChildProcess;
 	// helper to run commands and parse output
 	private streamCatcher: StreamCatcher = new StreamCatcher;
+	private runtimes = new Map<number, IDebuggerRuntime>();
 	// max tries to set a breakpoint
 	private maxBreakpointTries: number = 10;
 
@@ -65,6 +89,11 @@ export class PerlDebugSession extends LoggingDebugSession {
 	private sortKeys: boolean = false;
 
 	private deepcopy: boolean = false;
+	private terminatedDueToUnsupportedFork = false;
+	private debuggerServer?: Net.Server;
+	private debuggerSocket?: Net.Socket;
+	private nextChildThreadId = 2;
+	private executionInProgressThreads = new Set<number>();
 
 	constructor() {
 		super('perl-debug.txt');
@@ -99,11 +128,316 @@ export class PerlDebugSession extends LoggingDebugSession {
 	 * This function is used to send commands to the perl5db-process
 	 * and receive the output as an array of strings.
 	 */
-	private async request(command: string): Promise<string[]> {
+	private getRuntime(threadId: number): IDebuggerRuntime {
+		const runtime = this.runtimes.get(threadId);
+		if (!runtime) {
+			throw new Error(`No debugger runtime found for thread ${threadId}.`);
+		}
+		return runtime;
+	}
+
+	private registerPrimaryRuntime(output: Readable): void {
+		this.runtimes.set(PerlDebugSession.threadId, {
+			threadId: PerlDebugSession.threadId,
+			name: 'thread 1',
+			streamCatcher: this.streamCatcher,
+			isPrimary: true,
+			socket: output instanceof Net.Socket ? output : undefined
+		});
+		this.runtimeBreakpointsMap.set(PerlDebugSession.threadId, new Map());
+		this.runtimePostponedBreakpointsMap.set(PerlDebugSession.threadId, this.cloneBreakpointsMap(this.desiredPostponedBreakpointsMap));
+	}
+
+	private cloneBreakpoints(bps: IBreakpointData[]): IBreakpointData[] {
+		return bps.map((bp) => ({ ...bp }));
+	}
+
+	private cloneBreakpointsMap(source: Map<string, IBreakpointData[]>): Map<string, IBreakpointData[]> {
+		const copy = new Map<string, IBreakpointData[]>();
+		source.forEach((bps, scriptPath) => {
+			copy.set(scriptPath, this.cloneBreakpoints(bps));
+		});
+		return copy;
+	}
+
+	private setDesiredBreakpoints(scriptPath: string, bps: IBreakpointData[]): void {
+		const normalizedPath = this.normalizePathAndCasing(scriptPath);
+		this.desiredBreakpointsMap.set(normalizedPath, this.cloneBreakpoints(bps));
+	}
+
+	private getDesiredBreakpoints(scriptPath: string): IBreakpointData[] {
+		const normalizedPath = this.normalizePathAndCasing(scriptPath);
+		return this.cloneBreakpoints(this.desiredBreakpointsMap.get(normalizedPath) || []);
+	}
+
+	private setDesiredPostponedBreakpoints(scriptPath: string, bps: IBreakpointData[]): void {
+		const normalizedPath = this.normalizePathAndCasing(scriptPath);
+		this.desiredPostponedBreakpointsMap.set(normalizedPath, this.cloneBreakpoints(bps));
+	}
+
+	private deleteDesiredPostponedBreakpoints(scriptPath: string): void {
+		const normalizedPath = this.normalizePathAndCasing(scriptPath);
+		this.desiredPostponedBreakpointsMap.delete(normalizedPath);
+	}
+
+	private getDesiredPostponedEntries(): [string, IBreakpointData[]][] {
+		return Array.from(this.desiredPostponedBreakpointsMap.entries())
+			.map(([scriptPath, bps]) => [scriptPath, this.cloneBreakpoints(bps)]);
+	}
+
+	private getRuntimeBreakpoints(threadId: number): Map<string, IBreakpointData[]> {
+		if (!this.runtimeBreakpointsMap.has(threadId)) {
+			this.runtimeBreakpointsMap.set(threadId, new Map());
+		}
+		return this.runtimeBreakpointsMap.get(threadId)!;
+	}
+
+	private getRuntimePostponedBreakpoints(threadId: number): Map<string, IBreakpointData[]> {
+		if (!this.runtimePostponedBreakpointsMap.has(threadId)) {
+			this.runtimePostponedBreakpointsMap.set(threadId, this.cloneBreakpointsMap(this.desiredPostponedBreakpointsMap));
+		}
+		return this.runtimePostponedBreakpointsMap.get(threadId)!;
+	}
+
+	private getScopedVarRef(threadId: number, varRef: number): number {
+		return threadId * 100000 + varRef;
+	}
+
+	private peekVarRef(threadId: number): number {
+		if (!this.threadVarRef.has(threadId)) {
+			this.threadVarRef.set(threadId, 999);
+		}
+		return this.threadVarRef.get(threadId)!;
+	}
+
+	private consumeVarRef(threadId: number): number {
+		const nextRef = this.peekVarRef(threadId);
+		this.threadVarRef.set(threadId, nextRef - 1);
+		return nextRef;
+	}
+
+	private clearThreadScopedState(threadId: number): void {
+		this.threadVarRef.delete(threadId);
+		this.runtimeBreakpointsMap.delete(threadId);
+		this.runtimePostponedBreakpointsMap.delete(threadId);
+
+		this.frameThreadMap.forEach((mappedThreadId, frameId) => {
+			if (mappedThreadId === threadId) {
+				this.frameThreadMap.delete(frameId);
+			}
+		});
+
+		this.variableThreadMap.forEach((mappedThreadId, variableRef) => {
+			if (mappedThreadId === threadId) {
+				this.variableThreadMap.delete(variableRef);
+			}
+		});
+
+		this.childVarsMap.forEach((_variables, scopedVarRef) => {
+			if (Math.trunc(scopedVarRef / 100000) === threadId) {
+				this.childVarsMap.delete(scopedVarRef);
+			}
+		});
+		this.parentVarsMap.forEach((_variable, scopedVarRef) => {
+			if (Math.trunc(scopedVarRef / 100000) === threadId) {
+				this.parentVarsMap.delete(scopedVarRef);
+			}
+		});
+
+		if (this.currentStoppedThreadId === threadId) {
+			this.currentStoppedThreadId = PerlDebugSession.threadId;
+		}
+	}
+
+	private async registerChildRuntime(socket: Net.Socket): Promise<void> {
+		const threadId = this.nextChildThreadId++;
+		const childCatcher = new StreamCatcher();
+		this.runtimes.set(threadId, {
+			threadId,
+			name: `thread ${threadId}`,
+			streamCatcher: childCatcher,
+			isPrimary: false,
+			socket
+		});
+		this.runtimeBreakpointsMap.set(threadId, new Map());
+		this.runtimePostponedBreakpointsMap.set(threadId, this.cloneBreakpointsMap(this.desiredPostponedBreakpointsMap));
+
+		this.logSendEvent(new ThreadEvent('started', threadId));
+
+		socket.once('close', () => {
+			if (this.runtimes.delete(threadId)) {
+				this.clearThreadScopedState(threadId);
+				this.logSendEvent(new ThreadEvent('exited', threadId));
+			}
+		});
+
+		try {
+			await childCatcher.launch(socket, socket);
+			await this.syncRuntimeBreakpoints(threadId);
+			this.logSendEvent(new OutputEvent(
+				`Attached forked perl5db child transport to thread ${threadId}.\n`,
+				'important'
+			));
+			// Child is sitting at DB<n> prompt after sync — start it running.
+			// execute('c') will resolve when the child next stops (breakpoint/step/exit).
+			// Track in executionInProgressThreads to block duplicate continues until the
+			// first StoppedEvent is emitted.
+			this.executionInProgressThreads.add(threadId);
+			this.logSendEvent(new ContinuedEvent(threadId, false));
+			this.continue(threadId).catch((error) => {
+				if (this.runtimes.has(threadId)) {
+					this.logSendEvent(new OutputEvent(
+						`Child runtime thread ${threadId} continue error: ${error}\n`,
+						'important'
+					));
+				}
+			}).finally(() => {
+				this.executionInProgressThreads.delete(threadId);
+			});
+		} catch (error) {
+			this.logSendEvent(new OutputEvent(
+				`Failed to initialize forked perl5db child transport for thread ${threadId}: ${error}\n`,
+				'important'
+			));
+			socket.destroy();
+		}
+	}
+
+	private async syncRuntimeBreakpoints(threadId: number): Promise<void> {
+		const desiredEntries = Array.from(this.desiredBreakpointsMap.entries())
+			.map(([scriptPath, bps]) => [scriptPath, this.cloneBreakpoints(bps)] as [string, IBreakpointData[]]);
+		for (let i = 0; i < desiredEntries.length; i++) {
+			const [scriptPath, bps] = desiredEntries[i];
+			await this.applyBreakpointsToRuntime(scriptPath, bps, threadId);
+		}
+
+		for (let i = 0; i < this.funcBps.length; i++) {
+			const bp = this.funcBps[i];
+			await this.request(`b ${bp.name} ${bp.condition}`, threadId);
+		}
+	}
+
+	private async request(command: string, threadId: number = PerlDebugSession.threadId): Promise<string[]> {
+		const runtime = this.getRuntime(threadId);
 		logger.log(`Command: ${command}`);
-		const response = await this.streamCatcher.request(command);
+		const response = await runtime.streamCatcher.request(command);
 		logger.log(`Response for command ${command}: ${response.join('\n')}`);
 		return response;
+	}
+
+	private handleSessionOutput(data: string, category: 'stdout' | 'stderr'): void {
+		const output = data.replace(ansiSeq, '');
+		this.logSendEvent(new OutputEvent(output, category));
+
+		if (output.includes('Forked, but do not know how to create a new TTY')) {
+			this.handleUnsupportedFork();
+		}
+	}
+
+	private handleUnsupportedFork(): void {
+		if (this.terminatedDueToUnsupportedFork) {
+			return;
+		}
+
+		this.terminatedDueToUnsupportedFork = true;
+		this.logSendEvent(new OutputEvent(
+			'Forked Perl debugging is not supported by this adapter because perl5db requires a separate TTY for child debuggers. The session has been stopped to avoid corrupted state.',
+			'important'
+		));
+
+		if (this._session && !this._session.killed) {
+			this._session.kill();
+		}
+
+		this.logSendEvent(new TerminatedEvent());
+	}
+
+	private cleanupDebuggerTransport(): void {
+		this.frameThreadMap.clear();
+		this.variableThreadMap.clear();
+		this.threadVarRef.clear();
+		this.executionInProgressThreads.clear();
+		this.parentVarsMap.clear();
+		this.childVarsMap.clear();
+		this.runtimeBreakpointsMap.clear();
+		this.runtimePostponedBreakpointsMap.clear();
+
+		this.runtimes.forEach((runtime) => {
+			if (runtime.socket && !runtime.socket.destroyed) {
+				runtime.socket.destroy();
+			}
+		});
+		this.runtimes.clear();
+
+		if (this.debuggerSocket && !this.debuggerSocket.destroyed) {
+			this.debuggerSocket.destroy();
+		}
+		this.debuggerSocket = undefined;
+
+		if (this.debuggerServer) {
+			this.debuggerServer.close();
+		}
+		this.debuggerServer = undefined;
+	}
+
+	private buildPerlDbOptions(remotePort?: string): string {
+		const options = ['ReadLine=0'];
+		if (remotePort) {
+			options.push(`RemotePort=${remotePort}`);
+		}
+		return options.join(' ');
+	}
+
+	private async createSocketTransport(): Promise<{ remotePort: string; socketPromise: Promise<Net.Socket>; }> {
+		const server = Net.createServer((socket) => {
+			if (this.debuggerSocket) {
+				this.registerChildRuntime(socket).catch((error) => {
+					this.logSendEvent(new OutputEvent(`Could not register child runtime: ${error}\n`, 'important'));
+					socket.destroy();
+				});
+				return;
+			}
+
+			this.debuggerSocket = socket;
+		});
+		this.debuggerServer = server;
+
+		const socketPromise = new Promise<Net.Socket>((resolve, reject) => {
+			server.once('connection', (socket) => {
+				this.debuggerSocket = socket;
+				resolve(socket);
+			});
+			server.once('error', reject);
+		});
+
+		await new Promise<void>((resolve, reject) => {
+			server.once('error', reject);
+			server.listen(0, '127.0.0.1', () => {
+				resolve();
+			});
+		});
+
+		const address = server.address() as Net.AddressInfo;
+		return {
+			remotePort: `127.0.0.1:${address.port}`,
+			socketPromise
+		};
+	}
+
+	private async waitForDebuggerSocket(socketPromise: Promise<Net.Socket>): Promise<Net.Socket> {
+		return new Promise<Net.Socket>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				reject(new Error('Timed out waiting for perl5db to connect to the socket transport.'));
+			}, 5000);
+
+			socketPromise.then((socket) => {
+				clearTimeout(timeout);
+				resolve(socket);
+			}).catch((error) => {
+				clearTimeout(timeout);
+				reject(error);
+			});
+		});
 	}
 
 	/**
@@ -123,15 +457,15 @@ export class PerlDebugSession extends LoggingDebugSession {
 	/**
 	 * Changes the file context inside the perl5db-process.
 	 */
-	private async changeFileContext(filePath: string): Promise<string | undefined> {
+	private async changeFileContext(filePath: string, threadId: number = PerlDebugSession.threadId): Promise<string | undefined> {
 		let formattedPath = filePath
 			.replace(/\\{1,2}/g, '/')
 			.replace(/^\.\.\/+/g, '');
-		let data = (await this.request(`f ${formattedPath}`))[1];
+		let data = (await this.request(`f ${formattedPath}`, threadId))[1];
 		if (data.match(/^No file matching '.*' is loaded./)) {
 			logger.log(`Could not change file context: ${data}`);
 			formattedPath = basename(formattedPath);
-			data = (await this.request(`f ${formattedPath}`))[1];
+			data = (await this.request(`f ${formattedPath}`, threadId))[1];
 			if (data.match(/^No file matching '.*' is loaded./)) {
 				logger.log(`Could not change file context: ${data}`);
 				return undefined;
@@ -144,7 +478,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	/**
 	 * Sets breakpoints in a given perl file.
 	 */
-	private async setBreakpointsInFile(filePath: string, bps: DebugProtocol.SourceBreakpoint[]): Promise<Breakpoint[]> {
+	private async setBreakpointsInFile(filePath: string, bps: DebugProtocol.SourceBreakpoint[], threadId: number = PerlDebugSession.threadId): Promise<Breakpoint[]> {
 		const setBps: Breakpoint[] = [];
 		const mapBps: IBreakpointData[] = [];
 
@@ -152,7 +486,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 			let success = false;
 			let line = bps[i].line;
 			for (let tries = 0; success === false && tries < this.maxBreakpointTries; tries++) {
-				const data = (await this.request(`b ${line} ${bps[i].condition}`)).join('');
+				const data = (await this.request(`b ${line} ${bps[i].condition}`, threadId)).join('');
 				if (data.includes('not breakable')) {
 					// try again at the next line
 					line++;
@@ -175,9 +509,12 @@ export class PerlDebugSession extends LoggingDebugSession {
 		}
 
 		// save breakpoints inside the map
-		this.breakpointsMap.set(this.normalizePathAndCasing(filePath), mapBps);
-		// clear postponed breakpoints
-		this.postponedBreakpoints.delete(this.normalizePathAndCasing(filePath));
+		const normalizedPath = this.normalizePathAndCasing(filePath);
+		this.setDesiredBreakpoints(normalizedPath, mapBps);
+		this.getRuntimeBreakpoints(threadId).set(normalizedPath, this.cloneBreakpoints(mapBps));
+		// clear postponed breakpoints for this runtime
+		this.getRuntimePostponedBreakpoints(threadId).delete(normalizedPath);
+		this.deleteDesiredPostponedBreakpoints(normalizedPath);
 
 		return setBps;
 	}
@@ -185,18 +522,32 @@ export class PerlDebugSession extends LoggingDebugSession {
 	/**
 	 * Removes all breakpoints in a given perl file.
 	 */
-	private async removeBreakpointsInFile(filePath: string) {
+	private async removeBreakpointsInFile(filePath: string, threadId: number = PerlDebugSession.threadId) {
 		const scriptPath = this.normalizePathAndCasing(filePath);
+		const runtimeBps = this.getRuntimeBreakpoints(threadId);
 
-		const bps = this.breakpointsMap.get(scriptPath);
-		if (bps && (await this.changeFileContext(scriptPath))) {
+		const bps = runtimeBps.get(scriptPath);
+		if (bps && (await this.changeFileContext(scriptPath, threadId))) {
 			for (let i = 0; i < bps.length; i++) {
 				// remove the breakpoint inside the debugger
-				await this.request(`B ${bps[i].line}`);
+				await this.request(`B ${bps[i].line}`, threadId);
 			}
 		}
 
-		this.breakpointsMap.delete(this.normalizePathAndCasing(filePath));
+		runtimeBps.delete(scriptPath);
+	}
+
+	private async applyBreakpointsToRuntime(scriptPath: string, bps: IBreakpointData[], threadId: number): Promise<void> {
+		if (!(await this.changeFileContext(scriptPath, threadId))) {
+			this.getRuntimePostponedBreakpoints(threadId).set(scriptPath, this.cloneBreakpoints(bps));
+			return;
+		}
+		await this.removeBreakpointsInFile(scriptPath, threadId);
+		for (let i = 0; i < bps.length; i++) {
+			await this.request(`b ${bps[i].line} ${bps[i].condition}`, threadId);
+		}
+		this.getRuntimeBreakpoints(threadId).set(scriptPath, this.cloneBreakpoints(bps));
+		this.getRuntimePostponedBreakpoints(threadId).delete(scriptPath);
 	}
 
 	/**
@@ -209,13 +560,13 @@ export class PerlDebugSession extends LoggingDebugSession {
 	/**
 	 * Builds a variables expression using its parents ID and name.
 	 */
-	private getExpression(id: number, expression: string): string {
-		let lastParent: Variable | undefined = this.childVarsMap.get(id)?.find(e => { return e.name === expression; });
+	private getExpression(id: number, expression: string, threadId: number = PerlDebugSession.threadId): string {
+		let lastParent: Variable | undefined = this.childVarsMap.get(this.getScopedVarRef(threadId, id))?.find(e => { return e.name === expression; });
 		if (lastParent) {
 			let parentVars: Variable[] = [lastParent!];
 			let parent: Variable | undefined;
-			while ((parent = this.parentVarsMap.get(id)) && lastParent) {
-				const childrenOfParent = this.childVarsMap.get(id);
+			while ((parent = this.parentVarsMap.get(this.getScopedVarRef(threadId, id))) && lastParent) {
+				const childrenOfParent = this.childVarsMap.get(this.getScopedVarRef(threadId, id));
 				if (parent && childrenOfParent!.includes(lastParent)) {
 					parentVars.push(parent);
 					// we need to store the last parent variable to find the parent of the lastParent
@@ -291,11 +642,22 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArguments): Promise<void> {
+		let launchResponseSent = false;
+		const sendLaunchResponseOnce = () => {
+			if (!launchResponseSent) {
+				this.logSendResponse(response);
+				launchResponseSent = true;
+			}
+		};
+
+		this.terminatedDueToUnsupportedFork = false;
+		this.nextChildThreadId = 2;
+		this.cleanupDebuggerTransport();
 
 		// reset breakpointID and clear maps
 		this.currentBreakpointID = 1;
-		this.postponedBreakpoints.clear();
-		this.breakpointsMap.clear();
+		this.desiredPostponedBreakpointsMap.clear();
+		this.desiredBreakpointsMap.clear();
 
 		// set cwd
 		args.cwd = this.normalizePathAndCasing(args.cwd || dirname(args.program));
@@ -323,6 +685,15 @@ export class PerlDebugSession extends LoggingDebugSession {
 		// start the program in the runtime
 		// Spawn perl process and handle errors
 		logger.log(`CWD: ${args.cwd}`);
+		const transport = args.transport || 'stdio';
+		let remotePort: string | undefined;
+		let socketPromise: Promise<Net.Socket> | undefined;
+		if (transport === 'socket') {
+			const socketTransport = await this.createSocketTransport();
+			remotePort = socketTransport.remotePort;
+			socketPromise = socketTransport.socketPromise;
+		}
+
 		const env: NodeJS.ProcessEnv = {
 			...process.env,
 			...args.env,
@@ -335,7 +706,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			TERM: 'dumb',
 			// eslint-disable-next-line @typescript-eslint/naming-convention
-			PERLDB_OPTS: 'ReadLine=0'
+			PERLDB_OPTS: this.buildPerlDbOptions(remotePort)
 		};
 		const spawnOptions: SpawnOptions = {
 			detached: true,
@@ -388,6 +759,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		});
 
 		this._session.on('close', code => {
+			this.cleanupDebuggerTransport();
 			if (code === 255) {
 				this.logSendEvent(new OutputEvent(`${this.streamCatcher.getBuffer().splice(0, 7).join('\n')}\n`, 'stderr'));
 				this.logSendEvent(new TerminatedEvent());
@@ -396,6 +768,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		});
 
 		this._session.on('exit', code => {
+			this.cleanupDebuggerTransport();
 			if (code === 255) {
 				const text = `Could not start the debugging session! Script may contains errors. Code: ${code}\n${this.streamCatcher.getBuffer().splice(0, 7).join('\n')}\n`;
 				this.logSendEvent(new OutputEvent(text, 'stderr'));
@@ -404,15 +777,41 @@ export class PerlDebugSession extends LoggingDebugSession {
 			return;
 		});
 
-		// send the script output to the debug console
 		this._session.stdout!.on('data', (data) => {
-			this.logSendEvent(new OutputEvent(data.toString().replace(ansiSeq, ''), 'stdout'));
+			this.handleSessionOutput(data.toString(), 'stdout');
+		});
+		this._session.stderr!.on('data', (data) => {
+			this.handleSessionOutput(data.toString(), 'stderr');
 		});
 
+		let debuggerOutput: Readable = this._session.stderr!;
+		if (socketPromise) {
+			try {
+				debuggerOutput = await this.waitForDebuggerSocket(socketPromise);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : 'Unknown socket transport error.';
+				this.logSendEvent(new OutputEvent(`Could not establish the perl5db socket transport: ${message}\n`, 'important'));
+				this.cleanupDebuggerTransport();
+				if (this._session && !this._session.killed) {
+					this._session.kill();
+				}
+				response.success = false;
+				sendLaunchResponseOnce();
+				return;
+			}
+		}
+
+		let debuggerInput: Writable = this._session.stdin!;
+		if (transport === 'socket') {
+			debuggerInput = debuggerOutput as unknown as Writable;
+		}
+
 		await this.streamCatcher.launch(
-			this._session.stdin!,
-			this._session.stderr!
+			debuggerInput,
+			debuggerOutput
 		);
+		this.registerPrimaryRuntime(debuggerOutput);
+		sendLaunchResponseOnce();
 
 		// does the user want to debug the script or just run it?
 		if (args.debug === true || args.debug === undefined) {
@@ -442,18 +841,17 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 
 			// set as many breakpoints as early as possible
-			for (let scriptPath of this.postponedBreakpoints.keys()) {
-				const bps = this.postponedBreakpoints.get(scriptPath);
-				const fileChanged = await this.changeFileContext(scriptPath);
+			for (const [scriptPath, bps] of this.getDesiredPostponedEntries()) {
+				const fileChanged = await this.changeFileContext(scriptPath, PerlDebugSession.threadId);
 				if (bps && fileChanged) {
-					await this.setBreakpointsInFile(scriptPath, bps);
+					await this.setBreakpointsInFile(scriptPath, bps, PerlDebugSession.threadId);
 				}
 			}
 
 			// set function breakpoints
 			for (let i = 0; i < this.funcBps.length; i++) {
 				const bp = this.funcBps[i];
-				const data = (await this.request(`b ${bp.name} ${bp.condition}`))[1];
+				const data = (await this.request(`b ${bp.name} ${bp.condition}`, PerlDebugSession.threadId))[1];
 				if (data.includes('not found')) {
 					this.logSendEvent(new OutputEvent(`Could not set function breakpoint:\n${data}`, 'important'));
 				}
@@ -465,15 +863,19 @@ export class PerlDebugSession extends LoggingDebugSession {
 				this.logSendEvent(new StoppedEvent('entry', PerlDebugSession.threadId));
 			} else {
 				this.logSendEvent(new ContinuedEvent(PerlDebugSession.threadId));
-				await this.continue();
+				this.continue().catch((error) => {
+					this.logSendEvent(new OutputEvent(`Continue failed on primary runtime: ${error}\n`, 'important'));
+				});
 			}
+			return;
 		} else {
 			// Just run
 			this.logSendEvent(new ContinuedEvent(PerlDebugSession.threadId));
-			await this.continue();
+			this.continue().catch((error) => {
+				this.logSendEvent(new OutputEvent(`Continue failed on primary runtime: ${error}\n`, 'important'));
+			});
+			return;
 		}
-
-		this.logSendResponse(response);
 	}
 
 	protected async setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): Promise<void> {
@@ -483,13 +885,20 @@ export class PerlDebugSession extends LoggingDebugSession {
 		this.currentBreakpointID = 1;
 
 		// setting breakpoints is only possible if the runtime is currently active and the script is already loaded
-		if (this.isActive() && await this.changeFileContext(scriptPath)) {
-			// first we clear all existing breakpoints inside the file
-			await this.removeBreakpointsInFile(scriptPath);
-			// now we try to set every breakpoint requested
+		if (this.isActive() && await this.changeFileContext(scriptPath, PerlDebugSession.threadId)) {
+			// first we clear all existing breakpoints inside the file on primary runtime
+			await this.removeBreakpointsInFile(scriptPath, PerlDebugSession.threadId);
+			// now we try to set every breakpoint requested on primary runtime
 			response.body = {
-				breakpoints: await this.setBreakpointsInFile(scriptPath, argBps)
+				breakpoints: await this.setBreakpointsInFile(scriptPath, argBps, PerlDebugSession.threadId)
 			};
+
+			// mirror breakpoints to attached child runtimes
+			const childRuntimes = Array.from(this.runtimes.values()).filter((runtime) => runtime.threadId !== PerlDebugSession.threadId);
+			for (let i = 0; i < childRuntimes.length; i++) {
+				const runtime = childRuntimes[i];
+				await this.applyBreakpointsToRuntime(scriptPath, this.getDesiredBreakpoints(scriptPath), runtime.threadId);
+			}
 		} else {
 			logger.log('Can not set breakpoints. Runtime is not active yet or file not yet loaded');
 			// save breakpoints inside the map
@@ -506,7 +915,12 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 				this.currentBreakpointID++;
 			});
-			this.postponedBreakpoints.set(this.normalizePathAndCasing(scriptPath), mapBps);
+			this.setDesiredPostponedBreakpoints(scriptPath, mapBps);
+			const normalizedPath = this.normalizePathAndCasing(scriptPath);
+			const runtimes = Array.from(this.runtimes.values());
+			for (let i = 0; i < runtimes.length; i++) {
+				this.getRuntimePostponedBreakpoints(runtimes[i].threadId).set(normalizedPath, this.cloneBreakpoints(mapBps));
+			}
 			response.body = {
 				breakpoints: bps
 			};
@@ -524,7 +938,10 @@ export class PerlDebugSession extends LoggingDebugSession {
 			});
 
 			if (this.isActive()) {
-				await this.request(`b ${bp.name} ${bp.condition}`);
+				const runtimes = Array.from(this.runtimes.values());
+				for (let r = 0; r < runtimes.length; r++) {
+					await this.request(`b ${bp.name} ${bp.condition}`, runtimes[r].threadId);
+				}
 			} else {
 				logger.warn('Can not set function breakpoint. Runtime is not active yet');
 			}
@@ -534,37 +951,49 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	protected async threadsRequest(response: DebugProtocol.ThreadsResponse): Promise<void> {
+		const threads = Array.from(this.runtimes.values())
+			.map((runtime) => ({ id: runtime.threadId, name: runtime.name }))
+			.sort((a, b) => a.id - b.id);
+
 		response.body = {
-			threads: [{ id: PerlDebugSession.threadId, name: 'thread 1' }]
+			threads: threads.length > 0 ? threads : [{ id: PerlDebugSession.threadId, name: 'thread 1' }]
 		};
 		this.logSendResponse(response);
 	}
 
-	private async getStackFrames(): Promise<StackFrame[]> {
+	private async getStackFrames(threadId: number = PerlDebugSession.threadId): Promise<StackFrame[]> {
 		let stackFrames: StackFrame[] = [];
 		const stackTrace = /^[@|.]\s=\s(.*)\scalled\sfrom\sfile\s'(.*)'\sline\s(\d+)/;
+		const stackTraceDoubleQuote = /^[@|.]\s=\s(.*)\scalled\sfrom\sfile\s"(.*)"\sline\s(\d+)/;
+		const stackTraceUnquoted = /^[@|.]\s=\s(.*)\scalled\sfrom\sfile\s([^\s]+)\sline\s(\d+)/;
+		const atFormat = /^(.*)\sat\s(.*)\sline\s(\d+)\.?$/;
 		const evalTrace = /^\((eval\s\d+)\)\[(.*):(\d+)\]$/;
 
-		const lines = (await this.request('T')).slice(1, -1);
+		const lines = (await this.request('T', threadId)).slice(1, -1);
 		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
-			const matched = line.match(stackTrace);
+			const traceLine = lines[i];
+			const matched = traceLine.match(stackTrace)
+				|| traceLine.match(stackTraceDoubleQuote)
+				|| traceLine.match(stackTraceUnquoted)
+				|| traceLine.match(atFormat);
 			if (matched) {
 				let name = matched[1];
 				let file = matched[2];
-				let line = +matched[3];
+				let lineNumber = +matched[3];
 				const isEval = file.match(evalTrace);
 				if (isEval) {
 					name += ' (' + isEval[1] + ')';
 					file = isEval[2];
-					line = +isEval[3];
+					lineNumber = +isEval[3];
 				}
 				file = this.normalizePathAndCasing(file);
 				if (file.startsWith('.') || !path.isAbsolute(file)) {
 					file = join(this.cwd, file);
 				}
 				const fn = new Source(basename(file), file);
-				stackFrames.push(new StackFrame(i, name, fn, line));
+				const frameId = this.frameIdSeed++;
+				this.frameThreadMap.set(frameId, threadId);
+				stackFrames.push(new StackFrame(frameId, name, fn, lineNumber));
 			}
 		}
 
@@ -572,7 +1001,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	protected async stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): Promise<void> {
-		const stackFrames = await this.getStackFrames();
+		const threadId = args.threadId || PerlDebugSession.threadId;
+		this.currentStoppedThreadId = threadId;
+		const stackFrames = await this.getStackFrames(threadId);
 
 		response.body = {
 			stackFrames: stackFrames,
@@ -582,35 +1013,41 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	protected scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments): void {
+		const threadId = this.frameThreadMap.get(args.frameId) || this.currentStoppedThreadId;
+		const myRef = this._variableHandles.create({ scope: 'my', threadId });
+		const ourRef = this._variableHandles.create({ scope: 'our', threadId });
+		const specialRef = this._variableHandles.create({ scope: 'special', threadId });
+		this.variableThreadMap.set(myRef, threadId);
+		this.variableThreadMap.set(ourRef, threadId);
+		this.variableThreadMap.set(specialRef, threadId);
+
 		response.body = {
 			scopes: [
-				new Scope('My', this._variableHandles.create('my'), false),
-				new Scope('Our', this._variableHandles.create('our'), false),
-				new Scope('Specials', this._variableHandles.create('special'), true)
+				new Scope('My', myRef, false),
+				new Scope('Our', ourRef, false),
+				new Scope('Specials', specialRef, true)
 			]
 		};
-		// clear parsed variables and reset counter
-		this.parentVarsMap.clear();
-		this.childVarsMap.clear();
-		this.currentVarRef = 999;
+		this.threadVarRef.set(threadId, 999);
 		this.logSendResponse(response);
 	}
 
 	protected async variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments, _request?: DebugProtocol.Request): Promise<void> {
 		let varNames: string[] = [];
 		let parsedVars: Variable[] = [];
+		const threadId = this.variableThreadMap.get(args.variablesReference) || this.currentStoppedThreadId;
 		const handle = this._variableHandles.get(args.variablesReference);
 		// < 1000 => nested vars
 		if (args.variablesReference >= 1000) {
-			if (handle === 'my') {
-				varNames = (await this.request('print STDERR join ("|", sort(keys( % { PadWalker::peek_my(2); })))'))[1].split('|');
+			if (handle && handle.scope === 'my') {
+				varNames = (await this.request('print STDERR join ("|", sort(keys( % { PadWalker::peek_my(2); })))', threadId))[1].split('|');
 				logger.log(`Varnames: ${varNames.join(', ')}`);
 			}
-			if (handle === 'our') {
-				varNames = (await this.request('print STDERR join ("|", sort(keys( % { PadWalker::peek_our(2); })))'))[1].split('|');
+			if (handle && handle.scope === 'our') {
+				varNames = (await this.request('print STDERR join ("|", sort(keys( % { PadWalker::peek_our(2); })))', threadId))[1].split('|');
 				logger.log(`Varnames: ${varNames.join(', ')}`);
 			}
-			else if (handle === 'special') {
+			else if (handle && handle.scope === 'special') {
 				varNames = [
 					'%ENV',
 					'@ARGV',
@@ -649,7 +1086,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 			if (varNames[0] !== '') {
 				try {
-					parsedVars = await this.parseVars(varNames);
+					parsedVars = await this.parseVars(varNames, threadId);
 				} catch (error) {
 					this.logSendEvent(new OutputEvent(`Could not parse variables ${varNames}: ${error}`, 'stderr'));
 					response.success = false;
@@ -659,11 +1096,11 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 		} else {
 			// get already parsed vars from map
-			const newVars: DebugProtocol.Variable[] | undefined = this.childVarsMap.get(args.variablesReference);
+			const newVars: DebugProtocol.Variable[] | undefined = this.childVarsMap.get(this.getScopedVarRef(threadId, args.variablesReference));
 			// build expressions only for the variables which are displayed as it can be kinda costly
 			if (newVars) {
 				for (let i = 0; i < newVars.length; i++) {
-					newVars[i].evaluateName = this.getExpression(args.variablesReference, newVars[i].name);
+					newVars[i].evaluateName = this.getExpression(args.variablesReference, newVars[i].name, threadId);
 				}
 				parsedVars = parsedVars.concat(newVars);
 			}
@@ -677,6 +1114,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments, request?: DebugProtocol.Request): Promise<void> {
+		const threadId = args.frameId ? (this.frameThreadMap.get(args.frameId) || this.currentStoppedThreadId) : this.currentStoppedThreadId;
 		let varName: string;
 		// check if a variable is being evaluated
 		if (['$', '%', '@'].includes(args.expression.charAt(0))) {
@@ -698,8 +1136,8 @@ export class PerlDebugSession extends LoggingDebugSession {
 		}
 
 		// get variable value
-		const evaledVar: DebugProtocol.Variable = (await this.parseVars([varName]))[0];
-		evaledVar.evaluateName = this.getExpression(evaledVar.variablesReference, evaledVar.name);
+		const evaledVar: DebugProtocol.Variable = (await this.parseVars([varName], threadId))[0];
+		evaledVar.evaluateName = this.getExpression(evaledVar.variablesReference, evaledVar.name, threadId);
 
 		try {
 			response.body = {
@@ -713,7 +1151,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		this.logSendResponse(response);
 	}
 
-	private async parseVars(varNames: string[]): Promise<Variable[]> {
+	private async parseVars(varNames: string[], threadId: number = PerlDebugSession.threadId): Promise<Variable[]> {
 		let vs: DebugProtocol.Variable[] = [];
 		for (let i = 0; i < varNames.length; i++) {
 			let varName = varNames[i];
@@ -723,7 +1161,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 				varName = `{${varName}}`;
 			}
 
-			let varDump = (await this.request(`print STDERR Data::Dumper->new([${varName}], [])->Deepcopy(${this.deepcopy ? '1' : '0'})->Indent(1)->Terse(0)->Sortkeys(${this.sortKeys ? '1' : '0'})->Useqq(1)->Dump()`)).filter(e => { return e !== ''; }).slice(1, -1);
+			let varDump = (await this.request(`print STDERR Data::Dumper->new([${varName}], [])->Deepcopy(${this.deepcopy ? '1' : '0'})->Indent(1)->Terse(0)->Sortkeys(${this.sortKeys ? '1' : '0'})->Useqq(1)->Dump()`, threadId)).filter(e => { return e !== ''; }).slice(1, -1);
 			try {
 				while (true) {
 					// Continue every time we reach a breakpoint during this call until we have proper output
@@ -737,17 +1175,17 @@ export class PerlDebugSession extends LoggingDebugSession {
 						// check if we reached the end
 						if (varDump.join().includes('Debugged program terminated.')) {
 							// ensure that every script output is send to the debug console before closing the session
-							await this.request('sleep(.5)');
+							await this.request('sleep(.5)', threadId);
 							this.logSendEvent(new TerminatedEvent());
 							return [new Variable(varName, '')];
 						}
-						varDump = (await this.request('c')).filter(e => { return e !== ''; }).slice(1, -1);
+						varDump = (await this.request('c', threadId)).filter(e => { return e !== ''; }).slice(1, -1);
 					}
 				}
 			} catch (error) {
 				// Log error and continue with parsing the next variable
 				logger.error(`Could not parse variable ${varName}: ${varDump.join('\n')}`);
-				this.currentVarRef++;
+				this.consumeVarRef(threadId);
 				continue;
 			}
 			try {
@@ -767,9 +1205,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 							type: 'SCALAR'
 						});
 					} else {
-						this.currentVarRef--;
-						const ref = this.currentVarRef;
-						this.parseDumper(varDump.slice(1, -1));
+						const ref = this.consumeVarRef(threadId);
+						this.variableThreadMap.set(ref, threadId);
+						this.parseDumper(varDump.slice(1, -1), threadId);
 						const matched = varDump[varDump.length - 1].trim().match(this.isVarEnd);
 						if (matched) {
 							const type = `${(matched[1] === '}' ? 'HASH' : 'ARRAY')}${(matched[3] ? ` ${matched[3]}` : '')}`;
@@ -781,12 +1219,12 @@ export class PerlDebugSession extends LoggingDebugSession {
 								presentationHint: { kind: 'baseClass' }
 							};
 							if (type.startsWith('HASH')) {
-								newVar.namedVariables = this.childVarsMap.get(ref)?.length;
+								newVar.namedVariables = this.childVarsMap.get(this.getScopedVarRef(threadId, ref))?.length;
 							} else if (type.startsWith('ARRAY')) {
-								newVar.indexedVariables = this.childVarsMap.get(ref)?.length;
+								newVar.indexedVariables = this.childVarsMap.get(this.getScopedVarRef(threadId, ref))?.length;
 							}
 							vs.push(newVar);
-							this.parentVarsMap.set(ref, newVar);
+							this.parentVarsMap.set(this.getScopedVarRef(threadId, ref), newVar);
 						} else {
 							logger.error(`Could not parse variable end for ${varNames[i]}: ${varDump[varDump.length - 1]}`);
 							vs.push({
@@ -831,11 +1269,10 @@ export class PerlDebugSession extends LoggingDebugSession {
 	private isNestedArray = /^(bless\(\s*)?(\{|\[)$/;
 	private isVarEnd = /^(\}|\]),?(\s?'(.*)'\s\))?[,|;]?/;
 	// Parse output of Data::Dumper
-	private parseDumper(lines: string[]): { parsedLines: number, varType: string, numChildVars: number; } {
+	private parseDumper(lines: string[], threadId: number = PerlDebugSession.threadId): { parsedLines: number, varType: string, numChildVars: number; } {
 		let childVars: DebugProtocol.Variable[] = [];
 		let varType: string = '';
-		const ref: number = this.currentVarRef;
-		this.currentVarRef--;
+		const ref: number = this.consumeVarRef(threadId);
 
 		let i: number;
 		for (i = 0; i < lines.length; i++) {
@@ -875,14 +1312,16 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 			matched = line.match(this.isNestedArray);
 			if (matched) {
+				const childRef = this.peekVarRef(threadId);
 				const newVar: DebugProtocol.Variable = {
 					name: `${childVars.length}`,
 					value: '',
-					variablesReference: this.currentVarRef,
+					variablesReference: childRef,
 					presentationHint: { kind: 'innerClass' }
 				};
-				this.parentVarsMap.set(this.currentVarRef, newVar);
-				const parsed = this.parseDumper(lines.slice(i + 1));
+				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
+				this.variableThreadMap.set(childRef, threadId);
+				const parsed = this.parseDumper(lines.slice(i + 1), threadId);
 				i += parsed.parsedLines;
 				newVar.value = parsed.varType;
 				newVar.type = parsed.varType;
@@ -895,14 +1334,16 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 			matched = line.match(this.isNestedHash);
 			if (matched) {
+				const childRef = this.peekVarRef(threadId);
 				const newVar: DebugProtocol.Variable = {
 					name: matched[1],
 					value: '',
-					variablesReference: this.currentVarRef,
+					variablesReference: childRef,
 					presentationHint: { kind: 'innerClass' }
 				};
-				this.parentVarsMap.set(this.currentVarRef, newVar);
-				const parsed = this.parseDumper(lines.slice(i + 1));
+				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
+				this.variableThreadMap.set(childRef, threadId);
+				const parsed = this.parseDumper(lines.slice(i + 1), threadId);
 				i += parsed.parsedLines;
 				newVar.value = parsed.varType;
 				newVar.type = parsed.varType;
@@ -910,47 +1351,61 @@ export class PerlDebugSession extends LoggingDebugSession {
 				childVars.push(newVar);
 				continue;
 			}
-			logger.error(`Unrecognized Data::Dumper line: ${line}`);
-			logger.log(`All lines in current variable scope: ${lines.join('\n')}`);
+			if (line.trim() !== '') {
+				childVars.push({
+					name: `${childVars.length}`,
+					value: line.trim(),
+					variablesReference: 0,
+					presentationHint: { kind: 'data' },
+					type: 'SCALAR'
+				});
+			}
 		}
-		this.childVarsMap.set(ref, childVars);
+		this.childVarsMap.set(this.getScopedVarRef(threadId, ref), childVars);
 		return { parsedLines: i + 1, varType: varType, numChildVars: childVars.length };
 	}
 
 	protected async setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): Promise<void> {
-		const expressionToChange = this.getExpression(args.variablesReference, args.name);
-		const lines = (await this.request(`${expressionToChange} = ${args.value}`)).filter(e => { return e !== ''; });
+		const threadId = this.variableThreadMap.get(args.variablesReference) || this.currentStoppedThreadId;
+		const expressionToChange = this.getExpression(args.variablesReference, args.name, threadId);
+		const lines = (await this.request(`${expressionToChange} = ${args.value}`, threadId)).filter(e => { return e !== ''; });
 		if (lines.slice(1, -1).length > 0) {
 			this.logSendEvent(new OutputEvent(`Error setting value: ${lines.join(' ')}`, 'important'));
 			response.success = false;
 		} else {
-			const value = (await this.request(`print STDERR Data::Dumper->new([${(expressionToChange.startsWith('@') ? `[${expressionToChange}]` : (expressionToChange.startsWith('%') ? `{${expressionToChange}}` : expressionToChange))}], [])->Useqq(1)->Terse(1)->Dump()`)).slice(1, -1).join(' ');
+			const value = (await this.request(`print STDERR Data::Dumper->new([${(expressionToChange.startsWith('@') ? `[${expressionToChange}]` : (expressionToChange.startsWith('%') ? `{${expressionToChange}}` : expressionToChange))}], [])->Useqq(1)->Terse(1)->Dump()`, threadId)).slice(1, -1).join(' ');
 			response.body = { value: `${value.trim()}` };
 		}
 		this.logSendResponse(response);
 	}
 
 	protected async loadedSourcesRequest(response: DebugProtocol.LoadedSourcesResponse, args: DebugProtocol.LoadedSourcesArguments, request?: DebugProtocol.Request): Promise<void> {
-		let sources: Source[] = [];
-
-		const lines = await this.request('foreach my $INCKEY (keys %INC) { print STDERR "$INCKEY||$INC{$INCKEY}\\n" }');
-		// remove first and last line
-		lines.filter(e => { return e !== ''; }).slice(1, -1).forEach(line => {
-			const tmp = line.split('||');
-			if (tmp.length === 2) {
-				sources.push(new Source(tmp[0], tmp[1].replace(/^\.\//, `${this.cwd}/`)));
-			}
-		});
+		const uniqueSources = new Map<string, Source>();
+		const runtimes = Array.from(this.runtimes.values());
+		for (let i = 0; i < runtimes.length; i++) {
+			const runtime = runtimes[i];
+			const lines = await this.request('foreach my $INCKEY (keys %INC) { print STDERR "$INCKEY||$INC{$INCKEY}\\n" }', runtime.threadId);
+			// remove first and last line
+			lines.filter(e => { return e !== ''; }).slice(1, -1).forEach(line => {
+				const tmp = line.split('||');
+				if (tmp.length === 2) {
+					const fullPath = tmp[1].replace(/^\.\//, `${this.cwd}/`);
+					if (!uniqueSources.has(fullPath)) {
+						uniqueSources.set(fullPath, new Source(tmp[0], fullPath));
+					}
+				}
+			});
+		}
 
 		response.body = {
-			sources: sources
+			sources: Array.from(uniqueSources.values())
 		};
 
 		this.logSendResponse(response);
 	}
 
-	private async execute(cmd: string): Promise<void> {
-		const lines = await this.request(cmd);
+	private async execute(cmd: string, threadId: number = PerlDebugSession.threadId): Promise<void> {
+		const lines = await this.request(cmd, threadId);
 		const index = lines.findIndex(e => { return e.match(/^main::.*|^Debugged program terminated.*|^(continue\s)?loaded source.*/); });
 		const scriptOutput = lines.slice(1, index);
 		if (scriptOutput.filter(e => { return e !== ''; }).length > 0) {
@@ -958,9 +1413,19 @@ export class PerlDebugSession extends LoggingDebugSession {
 		}
 		// check if we reached the end
 		if (lines.join().includes('Debugged program terminated.')) {
-			// ensure that every script output is send to the debug console before closing the session
-			await this.request('sleep(.5)');
-			this.logSendEvent(new TerminatedEvent());
+			if (threadId === PerlDebugSession.threadId) {
+				// ensure that every script output is send to the debug console before closing the session
+				await this.request('sleep(.5)', threadId);
+				this.logSendEvent(new TerminatedEvent());
+			} else {
+				// Send 'q' to the child perl5db so the child OS process actually exits.
+				// This unblocks waitpid() in the parent and causes the socket 'close' event
+				// to fire, which emits ThreadEvent('exited') and cleans up thread state.
+				const runtime = this.runtimes.get(threadId);
+				if (runtime?.socket && !runtime.socket.destroyed) {
+					runtime.socket.write('q\n');
+				}
+			}
 			return;
 		}
 		// the reason why the debugger paused the execution
@@ -975,16 +1440,16 @@ export class PerlDebugSession extends LoggingDebugSession {
 					scriptPath = join(this.cwd, scriptPath);
 				}
 				scriptPath = this.normalizePathAndCasing(scriptPath);
-				const bps = this.postponedBreakpoints.get(scriptPath);
+				const bps = this.getRuntimePostponedBreakpoints(threadId).get(scriptPath);
 				if (bps) {
-					await this.setBreakpointsInFile(scriptPath, bps);
+					await this.setBreakpointsInFile(scriptPath, bps, threadId);
 					// check if we already reached a breakpoint at current position
 					// this can happen if the breakpoint is located at the first breakable line inside a file
-					const currentLine = (await this.getStackFrames())[0].line;
+					const currentLine = (await this.getStackFrames(threadId))[0].line;
 					for (let i = 0; i < bps.length; i++) {
 						const bp = bps[i];
 						if (bp.line === currentLine) {
-							this.logSendEvent(new StoppedEvent('breakpoint', PerlDebugSession.threadId));
+							this.logSendEvent(new StoppedEvent('breakpoint', threadId));
 							return;
 						}
 					}
@@ -992,7 +1457,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 			if (newSource.startsWith('continue') && (cmd === 'n' || cmd === 'c')) {
 				// just continue if the current command is continue or step over and the debugger allows it
-				await this.continue();
+				await this.continue(threadId);
 				return;
 			} else {
 				// else we stop on reaching a new source
@@ -1000,82 +1465,117 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 		} else {
 			if (cmd === 'c') {
+				// perl5db can occasionally pause after source loading even though no line
+				// breakpoint is configured at the current location. In that case we should
+				// continue automatically instead of surfacing a fake breakpoint stop.
+				if (this.funcBps.length === 0) {
+					const stackFrames = await this.getStackFrames(threadId);
+					const currentFrame = stackFrames[0];
+					const currentPath = currentFrame?.source?.path;
+					if (currentFrame && currentPath) {
+						const normalizedPath = this.normalizePathAndCasing(currentPath);
+						const runtimeBps = this.getRuntimeBreakpoints(threadId).get(normalizedPath) || [];
+						const isRealLineBreakpoint = runtimeBps.some((bp) => bp.line === currentFrame.line);
+						if (!isRealLineBreakpoint) {
+							await this.continue(threadId);
+							return;
+						}
+					}
+				}
 				reason = 'breakpoint';
 			} else {
 				reason = 'step';
 			}
 		}
-		this.logSendEvent(new StoppedEvent(reason, PerlDebugSession.threadId));
+		this.currentStoppedThreadId = threadId;
+		this.logSendEvent(new StoppedEvent(reason, threadId));
 	}
 
-	private async continue(): Promise<void> {
-		await this.execute('c');
+	private async continue(threadId: number = PerlDebugSession.threadId): Promise<void> {
+		await this.execute('c', threadId);
 	}
 
-	private pause(): boolean {
+	private pause(threadId: number = PerlDebugSession.threadId): boolean {
+		if (threadId !== PerlDebugSession.threadId) {
+			const runtime = this.runtimes.get(threadId);
+			if (runtime?.socket && !runtime.socket.destroyed) {
+				return runtime.socket.write('\u0003');
+			}
+			return false;
+		}
 		return this._session.kill('SIGINT');
 	}
 
-	private async next(): Promise<void> {
-		await this.execute('n');
+	private async next(threadId: number = PerlDebugSession.threadId): Promise<void> {
+		await this.execute('n', threadId);
 	}
 
-	private async stepIn(): Promise<void> {
-		await this.execute('s');
+	private async stepIn(threadId: number = PerlDebugSession.threadId): Promise<void> {
+		await this.execute('s', threadId);
 	}
 
-	private async stepOut(): Promise<void> {
-		await this.execute('r');
+	private async stepOut(threadId: number = PerlDebugSession.threadId): Promise<void> {
+		await this.execute('r', threadId);
 	}
 
-	protected continueRequest(response: DebugProtocol.ContinueResponse, _args: DebugProtocol.ContinueArguments): void {
-		this.logSendEvent(new ContinuedEvent(PerlDebugSession.threadId));
-		this.continue().then(() => {
+	private runExecutionControlRequest(
+		threadId: number,
+		response: DebugProtocol.Response,
+		requestName: string,
+		run: () => Promise<void>
+	): void {
+		if (this.executionInProgressThreads.has(threadId)) {
+			response.success = false;
+			this.logSendEvent(new OutputEvent(
+				`Ignored ${requestName} request for thread ${threadId} because another execution command is already running.\n`,
+				'important'
+			));
+			this.logSendResponse(response);
+			return;
+		}
+
+		this.executionInProgressThreads.add(threadId);
+		this.logSendEvent(new ContinuedEvent(threadId, false));
+		run().then(() => {
 			this.logSendResponse(response);
 		}).catch(() => {
 			response.success = false;
 			this.logSendResponse(response);
+		}).finally(() => {
+			this.executionInProgressThreads.delete(threadId);
 		});
 	}
 
+	protected continueRequest(response: DebugProtocol.ContinueResponse, _args: DebugProtocol.ContinueArguments): void {
+		const threadId = _args.threadId || PerlDebugSession.threadId;
+		this.runExecutionControlRequest(threadId, response, 'continue', () => this.continue(threadId));
+	}
+
 	protected pauseRequest(response: DebugProtocol.PauseResponse, _args: DebugProtocol.PauseArguments): void {
-		if (!this.pause()) {
+		const threadId = _args.threadId || PerlDebugSession.threadId;
+		if (!this.pause(threadId)) {
 			response.success = false;
 		}
 		this.logSendResponse(response);
 	}
 
 	protected nextRequest(response: DebugProtocol.NextResponse, _args: DebugProtocol.NextArguments): void {
-		this.logSendEvent(new ContinuedEvent(PerlDebugSession.threadId));
-		this.next().then(() => {
-			this.logSendResponse(response);
-		}).catch(() => {
-			response.success = false;
-			this.logSendResponse(response);
-		});
+		const threadId = _args.threadId || PerlDebugSession.threadId;
+		this.runExecutionControlRequest(threadId, response, 'next', () => this.next(threadId));
 	}
 
 	protected stepInRequest(response: DebugProtocol.StepInResponse, _args: DebugProtocol.StepInArguments): void {
-		this.logSendEvent(new ContinuedEvent(PerlDebugSession.threadId));
-		this.stepIn().then(() => {
-			this.logSendResponse(response);
-		}).catch(() => {
-			response.success = false;
-			this.logSendResponse(response);
-		});
+		const threadId = _args.threadId || PerlDebugSession.threadId;
+		this.runExecutionControlRequest(threadId, response, 'stepIn', () => this.stepIn(threadId));
 	}
 
 	protected stepOutRequest(response: DebugProtocol.StepOutResponse, _args: DebugProtocol.StepOutArguments, _request?: DebugProtocol.Request): void {
-		this.logSendEvent(new ContinuedEvent(PerlDebugSession.threadId));
-		this.stepOut().then(() => {
-			this.logSendResponse(response);
-		}).catch(() => {
-			response.success = false;
-			this.logSendResponse(response);
-		});
+		const threadId = _args.threadId || PerlDebugSession.threadId;
+		this.runExecutionControlRequest(threadId, response, 'stepOut', () => this.stepOut(threadId));
 	}
 
 	protected terminateRequest(response: DebugProtocol.TerminateResponse, _args: DebugProtocol.TerminateArguments, _request?: DebugProtocol.Request): void {
+		this.cleanupDebuggerTransport();
 		if (this._session) {
 			this._session.kill();
 		}

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -414,12 +414,52 @@ export class PerlDebugSession extends LoggingDebugSession {
 			'important'
 		));
 
-		if (this._session && !this._session.killed) {
-			this._session.kill();
-		}
+		this.terminateSessionProcessTree();
 
 		this.logSendEvent(new TerminatedEvent());
 	}
+
+	private terminateSessionProcessTree(): void {
+		if (!this._session) {
+			return;
+		}
+
+		const pid = this._session.pid;
+		if (!this._session.killed) {
+			try {
+				this._session.kill();
+			} catch {
+				// no-op
+			}
+		}
+
+		if (typeof pid !== 'number') {
+			return;
+		}
+
+		if (process.platform === 'win32') {
+			// Detached perl sessions can leave child processes alive on Windows.
+			// taskkill /T terminates the entire process tree.
+			const killer = spawn('taskkill', ['/PID', `${pid}`, '/T', '/F'], {
+				detached: true,
+				stdio: 'ignore'
+			});
+			killer.unref();
+			return;
+		}
+
+		try {
+			// For detached processes on POSIX the child runs in its own process group.
+			process.kill(-pid, 'SIGKILL');
+		} catch {
+			try {
+				process.kill(pid, 'SIGKILL');
+			} catch {
+				// no-op
+			}
+		}
+	}
+
 	private cleanupDebuggerTransport(): void {
 		this.activeTransport = 'stdio';
 		this.frameThreadMap.clear();
@@ -1038,7 +1078,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 		// was the last session already killed?
 		if (this._session && !this._session.killed) {
-			this._session.kill();
+			this.terminateSessionProcessTree();
 		}
 
 		// launch the debugger
@@ -1106,7 +1146,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 				this.logSendEvent(new OutputEvent(`Could not establish the perl5db socket transport: ${message}\n`, 'important'));
 				this.cleanupDebuggerTransport();
 				if (this._session && !this._session.killed) {
-					this._session.kill();
+					this.terminateSessionProcessTree();
 				}
 				response.success = false;
 				sendLaunchResponseOnce();
@@ -2075,9 +2115,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	protected terminateRequest(response: DebugProtocol.TerminateResponse, _args: DebugProtocol.TerminateArguments, _request?: DebugProtocol.Request): void {
 		this.cleanupDebuggerTransport();
-		if (this._session) {
-			this._session.kill();
-		}
+		this.terminateSessionProcessTree();
 		this.logSendEvent(new TerminatedEvent(false));
 		this.logSendResponse(response);
 	}

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -94,6 +94,8 @@ export class PerlDebugSession extends LoggingDebugSession {
 	private debuggerSocket?: Net.Socket;
 	private nextChildThreadId = 2;
 	private executionInProgressThreads = new Set<number>();
+	private forcedTopFrameByThread = new Map<number, { path: string; line: number }>();
+	private activeTransport: 'stdio' | 'socket' = 'stdio';
 
 	constructor() {
 		super('perl-debug.txt');
@@ -160,23 +162,57 @@ export class PerlDebugSession extends LoggingDebugSession {
 		return copy;
 	}
 
+	private normalizePathKey(filePath: string): string {
+		return this.normalizePathAndCasing(filePath);
+	}
+
+	private getPathMappedBreakpoints(
+		map: Map<string, IBreakpointData[]>,
+		scriptPath: string
+	): IBreakpointData[] | undefined {
+		const normalizedPath = this.normalizePathKey(scriptPath);
+		const direct = map.get(normalizedPath);
+		if (direct) {
+			return direct;
+		}
+
+		if (process.platform === 'win32') {
+			const lower = normalizedPath.toLowerCase();
+			const entries = Array.from(map.entries());
+			for (let i = 0; i < entries.length; i++) {
+				const [existingPath, bps] = entries[i];
+				if (this.normalizePathKey(existingPath).toLowerCase() === lower) {
+					return bps;
+				}
+			}
+		}
+
+		return undefined;
+	}
+
+	private samePath(left?: string, right?: string): boolean {
+		if (!left || !right) {
+			return false;
+		}
+		return this.normalizePathKey(left) === this.normalizePathKey(right);
+	}
+
 	private setDesiredBreakpoints(scriptPath: string, bps: IBreakpointData[]): void {
-		const normalizedPath = this.normalizePathAndCasing(scriptPath);
+		const normalizedPath = this.normalizePathKey(scriptPath);
 		this.desiredBreakpointsMap.set(normalizedPath, this.cloneBreakpoints(bps));
 	}
 
 	private getDesiredBreakpoints(scriptPath: string): IBreakpointData[] {
-		const normalizedPath = this.normalizePathAndCasing(scriptPath);
-		return this.cloneBreakpoints(this.desiredBreakpointsMap.get(normalizedPath) || []);
+		return this.cloneBreakpoints(this.getPathMappedBreakpoints(this.desiredBreakpointsMap, scriptPath) || []);
 	}
 
 	private setDesiredPostponedBreakpoints(scriptPath: string, bps: IBreakpointData[]): void {
-		const normalizedPath = this.normalizePathAndCasing(scriptPath);
+		const normalizedPath = this.normalizePathKey(scriptPath);
 		this.desiredPostponedBreakpointsMap.set(normalizedPath, this.cloneBreakpoints(bps));
 	}
 
 	private deleteDesiredPostponedBreakpoints(scriptPath: string): void {
-		const normalizedPath = this.normalizePathAndCasing(scriptPath);
+		const normalizedPath = this.normalizePathKey(scriptPath);
 		this.desiredPostponedBreakpointsMap.delete(normalizedPath);
 	}
 
@@ -278,7 +314,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 				`Attached forked perl5db child transport to thread ${threadId}.\n`,
 				'important'
 			));
-			// Child is sitting at DB<n> prompt after sync — start it running.
+			// Child is sitting at DB<n> prompt after sync - start it running.
 			// execute('c') will resolve when the child next stops (breakpoint/step/exit).
 			// Track in executionInProgressThreads to block duplicate continues until the
 			// first StoppedEvent is emitted.
@@ -329,7 +365,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		const output = data.replace(ansiSeq, '');
 		this.logSendEvent(new OutputEvent(output, category));
 
-		if (output.includes('Forked, but do not know how to create a new TTY')) {
+		if (this.activeTransport === 'stdio' && output.includes('Forked, but do not know how to create a new TTY')) {
 			this.handleUnsupportedFork();
 		}
 	}
@@ -352,6 +388,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		this.logSendEvent(new TerminatedEvent());
 	}
 	private cleanupDebuggerTransport(): void {
+		this.activeTransport = 'stdio';
 		this.frameThreadMap.clear();
 		this.variableThreadMap.clear();
 		this.threadVarRef.clear();
@@ -441,15 +478,17 @@ export class PerlDebugSession extends LoggingDebugSession {
 	/**
 	 * This function normalizes paths depending on the OS the debugger is running on.
 	 */
-	private normalizePathAndCasing(path: string): string {
+	private normalizePathAndCasing(pathStr: string): string {
 		if (process.platform === 'win32') {
-			const matched = path.match(/(^[a-z])(:\\.*)/);
+			pathStr = pathStr.replace(/\//g, '\\');
+			pathStr = path.win32.normalize(pathStr);
+			const matched = pathStr.match(/(^[a-z])(:[\\/].*)/);
 			if (matched) {
-				path = `${matched[1].toUpperCase()}${matched[2]}`;
+				pathStr = `${matched[1].toUpperCase()}${matched[2]}`;
 			}
-			return path.replace(/\//g, '\\');
+			return pathStr;
 		}
-		return path.replace(/\\/g, '/');
+		return path.posix.normalize(pathStr.replace(/\\/g, '/'));
 	}
 
 	/**
@@ -467,7 +506,11 @@ export class PerlDebugSession extends LoggingDebugSession {
 		for (let i = 0; i < candidates.length; i++) {
 			const candidate = candidates[i];
 			const data = (await this.request(`f ${candidate}`, threadId))[1];
-			if (!data.match(/^No file matching '.*' is loaded./)) {
+			const noFileMatch = data.match(/^No file matching '.*' is loaded\./);
+			// perl5db can emit hard errors for Windows-style absolute paths (e.g.
+			// "\\C no longer supported in regex") which must be treated as failure.
+			const hasError = /no longer supported in regex|\sat\s.*perl5db\.pl\sline\s\d+\.?|END failed--call queue aborted\./i.test(data);
+			if (!noFileMatch && !hasError) {
 				logger.log(`Successfully changed file context to ${candidate}: ${data}`);
 				return candidate;
 			}
@@ -514,7 +557,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		}
 
 		// save breakpoints inside the map
-		const normalizedPath = this.normalizePathAndCasing(filePath);
+		const normalizedPath = this.normalizePathKey(filePath);
 		this.setDesiredBreakpoints(normalizedPath, mapBps);
 		this.getRuntimeBreakpoints(threadId).set(normalizedPath, this.cloneBreakpoints(mapBps));
 		// clear postponed breakpoints for this runtime
@@ -528,10 +571,10 @@ export class PerlDebugSession extends LoggingDebugSession {
 	 * Removes all breakpoints in a given perl file.
 	 */
 	private async removeBreakpointsInFile(filePath: string, threadId: number = PerlDebugSession.threadId) {
-		const scriptPath = this.normalizePathAndCasing(filePath);
+		const scriptPath = this.normalizePathKey(filePath);
 		const runtimeBps = this.getRuntimeBreakpoints(threadId);
 
-		const bps = runtimeBps.get(scriptPath);
+		const bps = this.getPathMappedBreakpoints(runtimeBps, scriptPath);
 		if (bps && (await this.changeFileContext(scriptPath, threadId))) {
 			for (let i = 0; i < bps.length; i++) {
 				// remove the breakpoint inside the debugger
@@ -543,23 +586,28 @@ export class PerlDebugSession extends LoggingDebugSession {
 	}
 
 	private async applyBreakpointsToRuntime(scriptPath: string, bps: IBreakpointData[], threadId: number): Promise<void> {
+		const normalizedPath = this.normalizePathKey(scriptPath);
 		if (!(await this.changeFileContext(scriptPath, threadId))) {
-			this.getRuntimePostponedBreakpoints(threadId).set(scriptPath, this.cloneBreakpoints(bps));
+			this.getRuntimePostponedBreakpoints(threadId).set(normalizedPath, this.cloneBreakpoints(bps));
 			return;
 		}
 		await this.removeBreakpointsInFile(scriptPath, threadId);
 		for (let i = 0; i < bps.length; i++) {
 			await this.request(`b ${bps[i].line} ${bps[i].condition}`, threadId);
 		}
-		this.getRuntimeBreakpoints(threadId).set(scriptPath, this.cloneBreakpoints(bps));
-		this.getRuntimePostponedBreakpoints(threadId).delete(scriptPath);
+		this.getRuntimeBreakpoints(threadId).set(normalizedPath, this.cloneBreakpoints(bps));
+		this.getRuntimePostponedBreakpoints(threadId).delete(normalizedPath);
 	}
 
 	/**
 	 * Checks if the perl5db-runtime is currently active.
+	 * Requires the primary runtime to be registered: streamCatcher.launch() sets
+	 * this.streamCatcher.input on its very first line, before awaiting perl's first
+	 * prompt, so isActive() would return true during the startup window when runtimes
+	 * is still empty. Requiring runtimes.has(threadId) closes that window.
 	 */
 	private isActive(): boolean {
-		return !!(typeof this.streamCatcher.input !== 'undefined' && this.streamCatcher.input);
+		return !!(this.runtimes.has(PerlDebugSession.threadId) && this.streamCatcher.input);
 	}
 
 	/**
@@ -661,7 +709,10 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 		// reset breakpointID and clear maps
 		this.currentBreakpointID = 1;
-		this.desiredPostponedBreakpointsMap.clear();
+		// desiredPostponedBreakpointsMap is intentionally NOT cleared here: the IDE sends
+		// setBreakpoints during the configuration sequence (after InitializedEvent but before
+		// launch), and those breakpoints must survive into the launch body where they are
+		// applied to the freshly-started runtime.
 		this.desiredBreakpointsMap.clear();
 
 		// set cwd
@@ -690,7 +741,8 @@ export class PerlDebugSession extends LoggingDebugSession {
 		// start the program in the runtime
 		// Spawn perl process and handle errors
 		logger.log(`CWD: ${args.cwd}`);
-		const transport = args.transport || 'stdio';
+		const transport = args.transport || 'socket';
+		this.activeTransport = transport;
 		let remotePort: string | undefined;
 		let socketPromise: Promise<Net.Socket> | undefined;
 		if (transport === 'socket') {
@@ -831,6 +883,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 			// do not print return values on return-command
 			await this.request('o PrintRet=0');
 
+			// avoid stopping in END-frame internals when the debugged script exits
+			await this.request('o inhibit_exit=1');
+
 			// disable buffering to STDOUT
 			await this.request('$| = 1');
 
@@ -845,8 +900,15 @@ export class PerlDebugSession extends LoggingDebugSession {
 				return;
 			}
 
-			// set as many breakpoints as early as possible
+			// Apply pre-launch breakpoints for the main script only. At this point only
+			// the main script is guaranteed to be loaded in perl5db; breakpoints for other
+			// files remain in desiredPostponedBreakpointsMap and are applied when those
+			// files are loaded via the DB::postponed hook.
+			const mainScriptKey = this.normalizePathKey(args.program);
 			for (const [scriptPath, bps] of this.getDesiredPostponedEntries()) {
+				if (!this.samePath(scriptPath, mainScriptKey)) {
+					continue;
+				}
 				const fileChanged = await this.changeFileContext(scriptPath, PerlDebugSession.threadId);
 				if (bps && fileChanged) {
 					await this.setBreakpointsInFile(scriptPath, bps, PerlDebugSession.threadId);
@@ -890,7 +952,17 @@ export class PerlDebugSession extends LoggingDebugSession {
 		this.currentBreakpointID = 1;
 
 		// setting breakpoints is only possible if the runtime is currently active and the script is already loaded
-		if (this.isActive() && await this.changeFileContext(scriptPath, PerlDebugSession.threadId)) {
+		const active = this.isActive();
+		const currentFrames = active ? await this.getStackFrames(PerlDebugSession.threadId) : [];
+		const currentPath = currentFrames[0]?.source?.path;
+		const currentMatchesTarget = this.samePath(currentPath, scriptPath);
+		let loadedNow = false;
+		if (active && currentMatchesTarget) {
+			const activeContextPath = await this.changeFileContext(scriptPath, PerlDebugSession.threadId);
+			const expectedBase = basename(scriptPath).toLowerCase();
+			loadedNow = !!activeContextPath && basename(activeContextPath).toLowerCase() === expectedBase;
+		}
+		if (active && loadedNow) {
 			// first we clear all existing breakpoints inside the file on primary runtime
 			await this.removeBreakpointsInFile(scriptPath, PerlDebugSession.threadId);
 			// now we try to set every breakpoint requested on primary runtime
@@ -919,9 +991,10 @@ export class PerlDebugSession extends LoggingDebugSession {
 				bps.push(new Breakpoint(true, bp.line, undefined, new Source(scriptPath, scriptPath)));
 
 				this.currentBreakpointID++;
+
 			});
 			this.setDesiredPostponedBreakpoints(scriptPath, mapBps);
-			const normalizedPath = this.normalizePathAndCasing(scriptPath);
+			const normalizedPath = this.normalizePathKey(scriptPath);
 			const runtimes = Array.from(this.runtimes.values());
 			for (let i = 0; i < runtimes.length; i++) {
 				this.getRuntimePostponedBreakpoints(runtimes[i].threadId).set(normalizedPath, this.cloneBreakpoints(mapBps));
@@ -1002,13 +1075,49 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 		}
 
+		const normalizedCwd = this.normalizePathKey(this.cwd);
+		const workspaceFrames = stackFrames.filter((frame) => {
+			const framePath = frame.source?.path;
+			return !!framePath && this.normalizePathKey(framePath).startsWith(normalizedCwd);
+		});
+		if (workspaceFrames.length > 0) {
+			const nonWorkspaceFrames = stackFrames.filter((frame) => {
+				const framePath = frame.source?.path;
+				return !(!!framePath && this.normalizePathKey(framePath).startsWith(normalizedCwd));
+			});
+			stackFrames = workspaceFrames.concat(nonWorkspaceFrames);
+		}
+
 		return stackFrames;
 	}
+
+	private createSyntheticFrame(threadId: number, name: string, filePath: string, line: number): StackFrame {
+		const frameId = this.frameIdSeed++;
+		this.frameThreadMap.set(frameId, threadId);
+		const source = new Source(basename(filePath), filePath);
+		return new StackFrame(frameId, name, source, line);
+	}
+
+	private prependForcedStackFrame(threadId: number, stackFrames: StackFrame[]): StackFrame[] {
+		const forcedTopFrame = this.forcedTopFrameByThread.get(threadId);
+		if (!forcedTopFrame) {
+			return stackFrames;
+		}
+		const forced = this.createSyntheticFrame(threadId, 'main::loaded_source', forcedTopFrame.path, forcedTopFrame.line);
+		return [forced].concat(stackFrames);
+	}
+
 
 	protected async stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): Promise<void> {
 		const threadId = args.threadId || PerlDebugSession.threadId;
 		this.currentStoppedThreadId = threadId;
-		const stackFrames = await this.getStackFrames(threadId);
+		let stackFrames = await this.getStackFrames(threadId);
+		// prependForcedStackFrame handles the genuine "file just loaded, here is the breakpoint
+		// location" case (forcedTopFrameByThread set by execute handler). The former
+		// prependPostponedFallbackFrame was removed: it fired incorrectly whenever there were
+		// pre-launch pending breakpoints in runtimePostponedBreakpointsMap, masking the real
+		// entry-stop or breakpoint-stop location.
+		stackFrames = this.prependForcedStackFrame(threadId, stackFrames);
 
 		response.body = {
 			stackFrames: stackFrames,
@@ -1212,7 +1321,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 					} else {
 						const ref = this.consumeVarRef(threadId);
 						this.variableThreadMap.set(ref, threadId);
-						this.parseDumper(varDump.slice(1, -1), threadId);
+						this.parseDumper(varDump.slice(1, -1), threadId, ref);
 						const matched = varDump[varDump.length - 1].trim().match(this.isVarEnd);
 						if (matched) {
 							const type = `${(matched[1] === '}' ? 'HASH' : 'ARRAY')}${(matched[3] ? ` ${matched[3]}` : '')}`;
@@ -1270,45 +1379,26 @@ export class PerlDebugSession extends LoggingDebugSession {
 	// Regexp for parsing the output of Data::Dumper
 	private isNamedVariable = /"?(.*)"?\s=>?\s(undef|".*"|'.*'|-?\d+|\[\]|\{\}|bless\(.*\)|sub\s\{.*\}|\\\*\{".*\"}|\\{1,2}\*.*)[,|;]?$/;
 	private isIndexedVariable = /^(undef|".*"|'.*'|-?\d+|\[\]|\{\}|bless\(.*\)|sub\s\{.*\})[,|;]?/;
-	private isNestedHash = /"(.*)"\s=>?\s(?:bless\(\s*)?(\[|\{)\s*$/;
+	private isNestedHash = /^(.*?)\s=>?\s(?:bless\(\s*)?(\[|\{)\s*$/;
 	private isNestedArray = /^(bless\(\s*)?(\{|\[)$/;
 	private isVarEnd = /^(\}|\]),?(\s?'(.*)'\s\))?[,|;]?/;
 	// Parse output of Data::Dumper
-	private parseDumper(lines: string[], threadId: number = PerlDebugSession.threadId): { parsedLines: number, varType: string, numChildVars: number; } {
+	private parseDumper(lines: string[], threadId: number = PerlDebugSession.threadId, refOverride?: number): { parsedLines: number, varType: string, numChildVars: number; } {
 		let childVars: DebugProtocol.Variable[] = [];
 		let varType: string = '';
-		const ref: number = this.consumeVarRef(threadId);
+		const ref: number = typeof refOverride === 'number' ? refOverride : this.consumeVarRef(threadId);
 
 		let i: number;
 		for (i = 0; i < lines.length; i++) {
 			const line = lines[i];
-			let matched = line.match(this.isVarEnd);
+			const trimmedLine = line.trim();
+			let matched = trimmedLine.match(this.isVarEnd);
 			if (matched) {
 				varType = `${(matched[1] === '}' ? 'HASH' : 'ARRAY')}${(matched[3] ? ` ${matched[3]}` : '')}`;
 				break;
 			}
-			matched = line.match(this.isNamedVariable);
-			const nestedHash = line.match(this.isNestedHash);
-			if (nestedHash) {
-				const childRef = this.peekVarRef(threadId);
-				const newVar: DebugProtocol.Variable = {
-					name: nestedHash[1],
-					value: '',
-					variablesReference: childRef,
-					presentationHint: { kind: 'innerClass' }
-				};
-				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
-				this.variableThreadMap.set(childRef, threadId);
-				const parsed = this.parseDumper(lines.slice(i + 1), threadId);
-				i += parsed.parsedLines;
-				newVar.value = parsed.varType;
-				newVar.type = parsed.varType;
-				newVar.namedVariables = parsed.numChildVars;
-				childVars.push(newVar);
-				continue;
-			}
 
-			matched = line.match(this.isNamedVariable);
+			matched = trimmedLine.match(this.isNamedVariable);
 			if (matched) {
 				childVars.push({
 					name: matched[1].replace(/"/, ''),
@@ -1322,7 +1412,27 @@ export class PerlDebugSession extends LoggingDebugSession {
 				}
 				continue;
 			}
-			matched = line.match(this.isIndexedVariable);
+			matched = trimmedLine.match(this.isNestedHash);
+			if (matched) {
+				const childRef = this.consumeVarRef(threadId);
+				const keyName = (matched[1] || '').replace(/^['"]|['"]$/g, '');
+				const newVar: DebugProtocol.Variable = {
+					name: keyName,
+					value: '',
+					variablesReference: childRef,
+					presentationHint: { kind: 'innerClass' }
+				};
+				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
+				this.variableThreadMap.set(childRef, threadId);
+				const parsed = this.parseDumper(lines.slice(i + 1), threadId, childRef);
+				i += parsed.parsedLines;
+				newVar.value = parsed.varType;
+				newVar.type = parsed.varType;
+				newVar.namedVariables = parsed.numChildVars;
+				childVars.push(newVar);
+				continue;
+			}
+			matched = trimmedLine.match(this.isIndexedVariable);
 			if (matched) {
 				childVars.push({
 					name: `${childVars.length}`,
@@ -1336,9 +1446,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 				}
 				continue;
 			}
-			matched = line.match(this.isNestedArray);
+			matched = trimmedLine.match(this.isNestedArray);
 			if (matched) {
-				const childRef = this.peekVarRef(threadId);
+				const childRef = this.consumeVarRef(threadId);
 				const newVar: DebugProtocol.Variable = {
 					name: `${childVars.length}`,
 					value: '',
@@ -1347,7 +1457,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 				};
 				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
 				this.variableThreadMap.set(childRef, threadId);
-				const parsed = this.parseDumper(lines.slice(i + 1), threadId);
+				const parsed = this.parseDumper(lines.slice(i + 1), threadId, childRef);
 				i += parsed.parsedLines;
 				newVar.value = parsed.varType;
 				newVar.type = parsed.varType;
@@ -1356,25 +1466,6 @@ export class PerlDebugSession extends LoggingDebugSession {
 				if (childVars.length >= this.maxArrayElements) {
 					break;
 				}
-				continue;
-			}
-			matched = line.match(this.isNestedHash);
-			if (matched) {
-				const childRef = this.peekVarRef(threadId);
-				const newVar: DebugProtocol.Variable = {
-					name: matched[1],
-					value: '',
-					variablesReference: childRef,
-					presentationHint: { kind: 'innerClass' }
-				};
-				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
-				this.variableThreadMap.set(childRef, threadId);
-				const parsed = this.parseDumper(lines.slice(i + 1), threadId);
-				i += parsed.parsedLines;
-				newVar.value = parsed.varType;
-				newVar.type = parsed.varType;
-				newVar.namedVariables = parsed.numChildVars;
-				childVars.push(newVar);
 				continue;
 			}
 			if (line.trim() !== '') {
@@ -1433,6 +1524,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	private async execute(cmd: string, threadId: number = PerlDebugSession.threadId): Promise<void> {
 		const lines = await this.request(cmd, threadId);
+		this.forcedTopFrameByThread.delete(threadId);
 		const index = lines.findIndex(e => { return e.match(/^main::.*|^Debugged program terminated.*|^(continue\s)?loaded source.*/); });
 		const scriptOutput = lines.slice(1, index);
 		if (scriptOutput.filter(e => { return e !== ''; }).length > 0) {
@@ -1458,6 +1550,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 		// the reason why the debugger paused the execution
 		let reason: string;
 		const newSource = lines.find(ln => { return ln.match(/loaded source/); });
+		let loadedSourceHasPostponedBreakpoints = false;
+		let loadedSourcePathForStop: string | undefined;
+		let loadedSourcePreferredLine: number | undefined;
 		if (newSource) {
 			// set breakpoints in newly loaded file
 			const matched = newSource.match(/loaded source (.*)/);
@@ -1466,15 +1561,34 @@ export class PerlDebugSession extends LoggingDebugSession {
 				if (scriptPath.match(/^\./)) {
 					scriptPath = join(this.cwd, scriptPath);
 				}
-				scriptPath = this.normalizePathAndCasing(scriptPath);
-				const bps = this.getRuntimePostponedBreakpoints(threadId).get(scriptPath);
+				scriptPath = this.normalizePathKey(scriptPath);
+				const bps = this.getPathMappedBreakpoints(this.getRuntimePostponedBreakpoints(threadId), scriptPath);
+				loadedSourceHasPostponedBreakpoints = !!(bps && bps.length > 0);
+				loadedSourcePathForStop = scriptPath;
+				if (bps && bps.length > 0) {
+					loadedSourcePreferredLine = bps[0].line;
+				}
 				if (bps) {
-					await this.setBreakpointsInFile(scriptPath, bps, threadId);
+					const fileChanged = await this.changeFileContext(scriptPath, threadId);
+					if (!fileChanged) {
+						reason = 'new source';
+						this.currentStoppedThreadId = threadId;
+						this.logSendEvent(new StoppedEvent(reason, threadId));
+						return;
+					}
+					const appliedBreakpoints = await this.setBreakpointsInFile(scriptPath, bps, threadId);
+					const hasUnresolved = appliedBreakpoints.some((bp) => !bp.verified);
+					if (hasUnresolved) {
+						this.currentStoppedThreadId = threadId;
+						this.logSendEvent(new StoppedEvent('breakpoint', threadId));
+						return;
+					}
 					// check if we already reached a breakpoint at current position
 					// this can happen if the breakpoint is located at the first breakable line inside a file
 					const currentLine = (await this.getStackFrames(threadId))[0].line;
-					for (let i = 0; i < bps.length; i++) {
-						const bp = bps[i];
+					const runtimeBps = this.getPathMappedBreakpoints(this.getRuntimeBreakpoints(threadId), scriptPath) || bps;
+					for (let i = 0; i < runtimeBps.length; i++) {
+						const bp = runtimeBps[i];
 						if (bp.line === currentLine) {
 							this.logSendEvent(new StoppedEvent('breakpoint', threadId));
 							return;
@@ -1482,8 +1596,17 @@ export class PerlDebugSession extends LoggingDebugSession {
 					}
 				}
 			}
-			if (newSource.startsWith('continue') && (cmd === 'n' || cmd === 'c')) {
-				// just continue if the current command is continue or step over and the debugger allows it
+			if (cmd === 'c' && loadedSourceHasPostponedBreakpoints) {
+				await this.request('sleep(.05)', threadId);
+				if (loadedSourcePathForStop && loadedSourcePreferredLine) {
+					this.forcedTopFrameByThread.set(threadId, {
+						path: loadedSourcePathForStop,
+						line: loadedSourcePreferredLine
+					});
+				}
+				reason = 'breakpoint';
+			} else if (newSource.startsWith('continue') && (cmd === 'n' || cmd === 'c')) {
+				// Keep running for step-over or continue without postponed breakpoints.
 				await this.continue(threadId);
 				return;
 			} else {
@@ -1491,24 +1614,40 @@ export class PerlDebugSession extends LoggingDebugSession {
 				reason = 'new source';
 			}
 		} else {
-			if (cmd === 'c') {
-				// perl5db can occasionally pause after source loading even though no line
-				// breakpoint is configured at the current location. In that case we should
-				// continue automatically instead of surfacing a fake breakpoint stop.
-				if (this.funcBps.length === 0) {
-					const stackFrames = await this.getStackFrames(threadId);
-					const currentFrame = stackFrames[0];
-					const currentPath = currentFrame?.source?.path;
-					if (currentFrame && currentPath) {
-						const normalizedPath = this.normalizePathAndCasing(currentPath);
-						const runtimeBps = this.getRuntimeBreakpoints(threadId).get(normalizedPath) || [];
-						const isRealLineBreakpoint = runtimeBps.some((bp) => bp.line === currentFrame.line);
-						if (!isRealLineBreakpoint) {
-							await this.continue(threadId);
-							return;
-						}
+			const stoppedLocation = lines.find((line) => line.match(/^main::\((.*):(\d+)\):/));
+			const matchedLocation = stoppedLocation?.match(/^main::\((.*):(\d+)\):/);
+			if (matchedLocation) {
+				let stoppedPath = matchedLocation[1];
+				const isRelativeStoppedPath = stoppedPath.match(/^\./) !== null;
+				if (isRelativeStoppedPath) {
+					stoppedPath = join(this.cwd, stoppedPath);
+				}
+
+				const normalizedStoppedPath = this.normalizePathKey(stoppedPath);
+				const normalizedCwd = this.normalizePathKey(this.cwd);
+				const inWorkspace = normalizedStoppedPath.startsWith(normalizedCwd);
+
+				if (!inWorkspace) {
+					if (cmd === 'n') {
+						await this.next(threadId);
+					} else if (cmd === 'c') {
+						await this.continue(threadId);
+					}
+					return;
+				}
+
+				if (cmd === 'c' && this.funcBps.length === 0 && isRelativeStoppedPath) {
+					const stoppedLine = +matchedLocation[2];
+					const runtimeBps = this.getPathMappedBreakpoints(this.getRuntimeBreakpoints(threadId), normalizedStoppedPath) || [];
+					const isRealLineBreakpoint = runtimeBps.some((bp) => bp.line === stoppedLine);
+					if (!isRealLineBreakpoint) {
+						await this.continue(threadId);
+						return;
 					}
 				}
+			}
+
+			if (cmd === 'c') {
 				reason = 'breakpoint';
 			} else {
 				reason = 'step';

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -55,13 +55,31 @@ interface IScopeHandle {
 	threadId: number;
 }
 
+interface IContainerMeta {
+	expression: string;
+	type: 'ARRAY' | 'HASH';
+	total: number;
+}
+
+interface IChunkMeta {
+	parentExpression: string;
+	type: 'ARRAY' | 'HASH';
+	start: number;
+	end: number;
+}
+
 export class PerlDebugSession extends LoggingDebugSession {
 	private static threadId = 1;
+	private static readonly variableRefStart = 10000;
+	private static readonly maxVariableDumpContinueTries = 25;
 	private currentBreakpointID = 1;
 
 	private _variableHandles = new Handles<IScopeHandle>();
 	private childVarsMap = new Map<number, Variable[]>();
 	private parentVarsMap = new Map<number, Variable>();
+	private varExpressionMap = new Map<number, string>();
+	private containerMetaMap = new Map<number, IContainerMeta>();
+	private chunkMetaMap = new Map<number, IChunkMeta>();
 	private frameThreadMap = new Map<number, number>();
 	private variableThreadMap = new Map<number, number>();
 	private threadVarRef = new Map<number, number>();
@@ -241,14 +259,14 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	private peekVarRef(threadId: number): number {
 		if (!this.threadVarRef.has(threadId)) {
-			this.threadVarRef.set(threadId, 999);
+			this.threadVarRef.set(threadId, PerlDebugSession.variableRefStart);
 		}
 		return this.threadVarRef.get(threadId)!;
 	}
 
 	private consumeVarRef(threadId: number): number {
 		const nextRef = this.peekVarRef(threadId);
-		this.threadVarRef.set(threadId, nextRef - 1);
+		this.threadVarRef.set(threadId, nextRef + 1);
 		return nextRef;
 	}
 
@@ -277,6 +295,21 @@ export class PerlDebugSession extends LoggingDebugSession {
 		this.parentVarsMap.forEach((_variable, scopedVarRef) => {
 			if (Math.trunc(scopedVarRef / 100000) === threadId) {
 				this.parentVarsMap.delete(scopedVarRef);
+			}
+		});
+		this.varExpressionMap.forEach((_expression, scopedVarRef) => {
+			if (Math.trunc(scopedVarRef / 100000) === threadId) {
+				this.varExpressionMap.delete(scopedVarRef);
+			}
+		});
+		this.containerMetaMap.forEach((_meta, scopedVarRef) => {
+			if (Math.trunc(scopedVarRef / 100000) === threadId) {
+				this.containerMetaMap.delete(scopedVarRef);
+			}
+		});
+		this.chunkMetaMap.forEach((_meta, scopedVarRef) => {
+			if (Math.trunc(scopedVarRef / 100000) === threadId) {
+				this.chunkMetaMap.delete(scopedVarRef);
 			}
 		});
 
@@ -658,6 +691,229 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 		}
 		return expression;
+	}
+
+	private normalizeExpressionForContainer(expression: string): string {
+		if (expression.startsWith('[') && expression.endsWith(']')) {
+			return this.normalizeExpressionForContainer(expression.slice(1, -1));
+		}
+		if (expression.startsWith('{') && expression.endsWith('}')) {
+			return this.normalizeExpressionForContainer(expression.slice(1, -1));
+		}
+		if (expression.startsWith('@') || expression.startsWith('%')) {
+			return `$${expression.slice(1)}`;
+		}
+		return expression;
+	}
+
+	private buildIndexedExpression(parentExpression: string, index: number): string {
+		const normalized = this.normalizeExpressionForContainer(parentExpression);
+		return `${normalized}[${index}]`;
+	}
+
+	private buildNamedExpression(parentExpression: string, key: string): string {
+		const normalized = this.normalizeExpressionForContainer(parentExpression);
+		const escaped = key.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+		return `${(normalized.endsWith(']') ? `${normalized}->` : normalized)}{'${escaped}'}`;
+	}
+
+	private buildHashKeySliceExpression(parentExpression: string, start: number, end: number): string {
+		const keysSource = parentExpression.startsWith('%')
+			? `keys ${parentExpression}`
+			: `do { my $__h = ${this.normalizeExpressionForContainer(parentExpression)}; keys %{$__h} }`;
+		return `do { my @k = ${keysSource}; my $all_numeric = 1; for my $k (@k) { if ($k !~ /^-?\\d+$/) { $all_numeric = 0; last; } } @k = $all_numeric ? sort { $a <=> $b } @k : sort { $a cmp $b } @k; @k[${start}..${end}] }`;
+	}
+
+	private hasDebuggerCommandError(lines: string[]): boolean {
+		const payload = lines.slice(1, -1).filter((line) => line !== '');
+		if (payload.length === 0) {
+			return false;
+		}
+		return payload.some((line) => /syntax error|Compilation failed|Undefined subroutine|Modification of a read-only value attempted|Can't locate|Can't use|Can't modify|no longer supported in regex|\sat\s.*line\s\d+\.?/i.test(line));
+	}
+
+	private countChar(line: string, charToCount: string): number {
+		let count = 0;
+		for (let i = 0; i < line.length; i++) {
+			if (line.charAt(i) === charToCount) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	private skipNestedBlock(lines: string[], startIndex: number, openChar: string): number {
+		const closeChar = openChar === '{' ? '}' : ']';
+		let depth = this.countChar(lines[startIndex], openChar) - this.countChar(lines[startIndex], closeChar);
+		let index = startIndex;
+		while (depth > 0 && index + 1 < lines.length) {
+			index++;
+			const current = lines[index];
+			depth += this.countChar(current, openChar);
+			depth -= this.countChar(current, closeChar);
+		}
+		return index;
+	}
+
+	private toDumperExpression(expression: string): string {
+		if (expression.startsWith('@')) {
+			return `[${expression}]`;
+		}
+		if (expression.startsWith('%')) {
+			return `{${expression}}`;
+		}
+		return expression;
+	}
+
+	private buildOutputPrintCommand(payload: string): string {
+		if (this.activeTransport === 'socket') {
+			return `print {$DB::OUT} ${payload}`;
+		}
+		return `print STDERR ${payload}`;
+	}
+
+	private extractCommandPayload(lines: string[]): string[] {
+		return lines
+			.filter((line) => line !== '')
+			.slice(1, -1)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+	}
+
+	private async getContainerSize(expression: string, type: 'ARRAY' | 'HASH', threadId: number): Promise<number> {
+		const normalized = this.normalizeExpressionForContainer(expression);
+		let perlExpr: string;
+		if (type === 'ARRAY') {
+			if (expression.startsWith('@')) {
+				perlExpr = `scalar(${expression})`;
+			} else {
+				perlExpr = `do { my $__v = ${normalized}; ref($__v) eq 'ARRAY' ? scalar(@{$__v}) : 0 }`;
+			}
+		} else {
+			if (expression.startsWith('%')) {
+				perlExpr = `scalar(keys ${expression})`;
+			} else {
+				perlExpr = `do { my $__v = ${normalized}; ref($__v) eq 'HASH' ? scalar(keys %{$__v}) : 0 }`;
+			}
+		}
+
+		const payload = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand(`${perlExpr} . "\\n"`), threadId));
+		if (payload.length === 0) {
+			return 0;
+		}
+		const parsed = parseInt(payload[payload.length - 1], 10);
+		return Number.isNaN(parsed) ? 0 : parsed;
+	}
+
+	private createChunkNodesForContainer(ref: number, threadId: number, meta: IContainerMeta): Variable[] {
+		const chunkSize = meta.type === 'HASH' ? this.maxHashElements : this.maxArrayElements;
+		if (chunkSize <= 0 || meta.total <= chunkSize) {
+			return [];
+		}
+
+		const scopedRef = this.getScopedVarRef(threadId, ref);
+		const chunks: DebugProtocol.Variable[] = [];
+		for (let start = 0; start < meta.total; start += chunkSize) {
+			const end = Math.min(start + chunkSize, meta.total) - 1;
+			const chunkRef = this.consumeVarRef(threadId);
+			this.variableThreadMap.set(chunkRef, threadId);
+			this.chunkMetaMap.set(this.getScopedVarRef(threadId, chunkRef), {
+				parentExpression: meta.expression,
+				type: meta.type,
+				start,
+				end
+			});
+			chunks.push({
+				name: meta.type === 'HASH' ? `[keys ${start}..${end}]` : `[${start}..${end}]`,
+				value: `${meta.type} CHUNK`,
+				type: meta.type,
+				variablesReference: chunkRef,
+				// Keep evaluateName on the container expression to avoid bogus expressions
+				// like $large_array[[0..99]].
+				evaluateName: this.normalizeExpressionForContainer(meta.expression),
+				presentationHint: { kind: 'data' }
+			});
+		}
+		this.childVarsMap.set(scopedRef, chunks as Variable[]);
+		return chunks as Variable[];
+	}
+
+	private shouldExposeContainerCount(type: 'ARRAY' | 'HASH', total: number): boolean {
+		const chunkSize = type === 'HASH' ? this.maxHashElements : this.maxArrayElements;
+		return chunkSize <= 0 || total <= chunkSize;
+	}
+
+	private async loadChunkChildren(chunkRef: number, threadId: number, chunk: IChunkMeta): Promise<Variable[]> {
+		if (chunk.type === 'ARRAY') {
+			const parentExpr = chunk.parentExpression;
+			const dumpExpr = parentExpr.startsWith('@')
+				? `[@{[ ${parentExpr}[${chunk.start}..${chunk.end}] ]}]`
+				: `[ @{ ${this.normalizeExpressionForContainer(parentExpr)} }[${chunk.start}..${chunk.end}] ]`;
+			const varDump = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand(`Data::Dumper->new([${dumpExpr}], [])->Deepcopy(${this.deepcopy ? '1' : '0'})->Indent(1)->Terse(0)->Sortkeys(${this.sortKeys ? '1' : '0'})->Useqq(1)->Dump()`), threadId));
+			if (varDump.length === 0) {
+				this.childVarsMap.set(this.getScopedVarRef(threadId, chunkRef), []);
+				return [];
+			}
+			this.parseDumper(varDump.slice(1, -1), threadId, chunkRef, `@chunk`);
+			const vars = this.childVarsMap.get(this.getScopedVarRef(threadId, chunkRef)) || [];
+			for (let i = 0; i < vars.length; i++) {
+				vars[i].name = `${chunk.start + i}`;
+				(vars[i] as DebugProtocol.Variable).evaluateName = this.buildIndexedExpression(parentExpr, chunk.start + i);
+			}
+			this.childVarsMap.set(this.getScopedVarRef(threadId, chunkRef), vars);
+			return vars;
+		}
+
+		const parentExpr = chunk.parentExpression;
+		const keysExpr = this.buildHashKeySliceExpression(parentExpr, chunk.start, chunk.end);
+		const keysPayload = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand(`join("\\t", ${keysExpr}) . "\\n"`), threadId));
+		const keys = keysPayload.length > 0 ? keysPayload[keysPayload.length - 1].split('\t').filter((k) => k.length > 0) : [];
+		const vars: DebugProtocol.Variable[] = [];
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i];
+			const valueExpr = this.buildNamedExpression(parentExpr, key);
+			const one = await this.parseVars([valueExpr], threadId);
+			if (one.length > 0) {
+				const entry = one[0];
+				entry.name = key;
+				(entry as DebugProtocol.Variable).evaluateName = valueExpr;
+				vars.push(entry);
+			}
+		}
+		this.childVarsMap.set(this.getScopedVarRef(threadId, chunkRef), vars as Variable[]);
+		return vars as Variable[];
+	}
+
+	private async loadContainerChildren(ref: number, threadId: number): Promise<Variable[] | undefined> {
+		const scopedRef = this.getScopedVarRef(threadId, ref);
+		const chunk = this.chunkMetaMap.get(scopedRef);
+		if (chunk) {
+			return this.loadChunkChildren(ref, threadId, chunk);
+		}
+
+		const meta = this.containerMetaMap.get(scopedRef);
+		if (meta) {
+			const chunkNodes = this.createChunkNodesForContainer(ref, threadId, meta);
+			if (chunkNodes.length > 0) {
+				return chunkNodes;
+			}
+		}
+
+		const expression = this.varExpressionMap.get(scopedRef);
+		if (!expression) {
+			return undefined;
+		}
+
+		const dumpExpression = this.toDumperExpression(expression);
+		const varDump = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand(`Data::Dumper->new([${dumpExpression}], [])->Deepcopy(${this.deepcopy ? '1' : '0'})->Indent(1)->Terse(0)->Sortkeys(${this.sortKeys ? '1' : '0'})->Useqq(1)->Dump()`), threadId));
+
+		if (varDump.length === 0) {
+			this.childVarsMap.set(scopedRef, []);
+			return [];
+		}
+
+		this.parseDumper(varDump.slice(1, -1), threadId, ref, expression);
+		return this.childVarsMap.get(scopedRef);
 	}
 
 	/**
@@ -1142,7 +1398,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 				new Scope('Specials', specialRef, true)
 			]
 		};
-		this.threadVarRef.set(threadId, 999);
+		this.threadVarRef.set(threadId, PerlDebugSession.variableRefStart);
 		this.logSendResponse(response);
 	}
 
@@ -1151,17 +1407,18 @@ export class PerlDebugSession extends LoggingDebugSession {
 		let parsedVars: Variable[] = [];
 		const threadId = this.variableThreadMap.get(args.variablesReference) || this.currentStoppedThreadId;
 		const handle = this._variableHandles.get(args.variablesReference);
-		// < 1000 => nested vars
-		if (args.variablesReference >= 1000) {
-			if (handle && handle.scope === 'my') {
-				varNames = (await this.request('print STDERR join ("|", sort(keys( % { PadWalker::peek_my(2); })))', threadId))[1].split('|');
+		if (handle) {
+			if (handle.scope === 'my') {
+				const payload = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand('join ("|", sort(keys( % { PadWalker::peek_my(2); }))) . "\\n"'), threadId));
+				varNames = payload.length > 0 ? payload[payload.length - 1].split('|') : [''];
 				logger.log(`Varnames: ${varNames.join(', ')}`);
 			}
-			if (handle && handle.scope === 'our') {
-				varNames = (await this.request('print STDERR join ("|", sort(keys( % { PadWalker::peek_our(2); })))', threadId))[1].split('|');
+			if (handle.scope === 'our') {
+				const payload = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand('join ("|", sort(keys( % { PadWalker::peek_our(2); }))) . "\\n"'), threadId));
+				varNames = payload.length > 0 ? payload[payload.length - 1].split('|') : [''];
 				logger.log(`Varnames: ${varNames.join(', ')}`);
 			}
-			else if (handle && handle.scope === 'special') {
+			else if (handle.scope === 'special') {
 				varNames = [
 					'%ENV',
 					'@ARGV',
@@ -1210,11 +1467,16 @@ export class PerlDebugSession extends LoggingDebugSession {
 			}
 		} else {
 			// get already parsed vars from map
-			const newVars: DebugProtocol.Variable[] | undefined = this.childVarsMap.get(this.getScopedVarRef(threadId, args.variablesReference));
+			let newVars: DebugProtocol.Variable[] | undefined = this.childVarsMap.get(this.getScopedVarRef(threadId, args.variablesReference));
+			if (!newVars) {
+				newVars = await this.loadContainerChildren(args.variablesReference, threadId);
+			}
 			// build expressions only for the variables which are displayed as it can be kinda costly
 			if (newVars) {
 				for (let i = 0; i < newVars.length; i++) {
-					newVars[i].evaluateName = this.getExpression(args.variablesReference, newVars[i].name, threadId);
+					if (!newVars[i].evaluateName) {
+						newVars[i].evaluateName = this.getExpression(args.variablesReference, newVars[i].name, threadId);
+					}
 				}
 				parsedVars = parsedVars.concat(newVars);
 			}
@@ -1243,12 +1505,6 @@ export class PerlDebugSession extends LoggingDebugSession {
 			return;
 		}
 
-		if (varName.startsWith('@')) {
-			varName = `[${varName}]`;
-		} else if (varName.startsWith('%')) {
-			varName = `{${varName}}`;
-		}
-
 		// get variable value
 		const evaledVar: DebugProtocol.Variable = (await this.parseVars([varName], threadId))[0];
 		evaledVar.evaluateName = this.getExpression(evaledVar.variablesReference, evaledVar.name, threadId);
@@ -1268,20 +1524,48 @@ export class PerlDebugSession extends LoggingDebugSession {
 	private async parseVars(varNames: string[], threadId: number = PerlDebugSession.threadId): Promise<Variable[]> {
 		let vs: DebugProtocol.Variable[] = [];
 		for (let i = 0; i < varNames.length; i++) {
-			let varName = varNames[i];
-			if (varName.startsWith('@')) {
-				varName = `[${varName}]`;
-			} else if (varName.startsWith('%')) {
-				varName = `{${varName}}`;
+			const originalExpression = varNames[i];
+			if (originalExpression.startsWith('@') || originalExpression.startsWith('%')) {
+				const ref = this.consumeVarRef(threadId);
+				this.variableThreadMap.set(ref, threadId);
+				this.varExpressionMap.set(this.getScopedVarRef(threadId, ref), originalExpression);
+				const containerType = originalExpression.startsWith('@') ? 'ARRAY' : 'HASH';
+				const total = await this.getContainerSize(originalExpression, containerType, threadId);
+				this.containerMetaMap.set(this.getScopedVarRef(threadId, ref), {
+					expression: originalExpression,
+					type: containerType,
+					total
+				});
+				const newVar: DebugProtocol.Variable = {
+					name: originalExpression,
+					value: containerType,
+					variablesReference: ref,
+					evaluateName: originalExpression,
+					presentationHint: { kind: 'baseClass' }
+				};
+				if (containerType === 'HASH' && this.shouldExposeContainerCount(containerType, total)) {
+					newVar.namedVariables = total;
+				} else if (containerType === 'ARRAY' && this.shouldExposeContainerCount(containerType, total)) {
+					newVar.indexedVariables = total;
+				}
+				vs.push(newVar);
+				this.parentVarsMap.set(this.getScopedVarRef(threadId, ref), newVar);
+				continue;
 			}
 
-			let varDump = (await this.request(`print STDERR Data::Dumper->new([${varName}], [])->Deepcopy(${this.deepcopy ? '1' : '0'})->Indent(1)->Terse(0)->Sortkeys(${this.sortKeys ? '1' : '0'})->Useqq(1)->Dump()`, threadId)).filter(e => { return e !== ''; }).slice(1, -1);
+			const dumpExpression = this.toDumperExpression(originalExpression);
+			let varDump = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand(`Data::Dumper->new([${dumpExpression}], [])->Deepcopy(${this.deepcopy ? '1' : '0'})->Indent(1)->Terse(0)->Sortkeys(${this.sortKeys ? '1' : '0'})->Useqq(1)->Dump()`), threadId));
 			try {
+				let continueTries = 0;
 				while (true) {
 					// Continue every time we reach a breakpoint during this call until we have proper output
-					if (varDump[0].match(/^\$VAR1\s=\s.*/)) {
+					if (varDump[0] && varDump[0].match(/^\$VAR1\s=\s.*/)) {
 						break;
-					} else if (varDump[0].match(/^.* at .* line \d+\.$/)) {
+					} else if (varDump[0] && varDump[0].match(/^.* at .* line \d+\.$/)) {
+						varDump = [];
+						break;
+					} else if (continueTries >= PerlDebugSession.maxVariableDumpContinueTries) {
+						logger.error(`Reached max variable dump retries for ${originalExpression}`);
 						varDump = [];
 						break;
 					} else {
@@ -1291,14 +1575,15 @@ export class PerlDebugSession extends LoggingDebugSession {
 							// ensure that every script output is send to the debug console before closing the session
 							await this.request('sleep(.5)', threadId);
 							this.logSendEvent(new TerminatedEvent());
-							return [new Variable(varName, '')];
+							return [new Variable(originalExpression, '')];
 						}
+						continueTries++;
 						varDump = (await this.request('c', threadId)).filter(e => { return e !== ''; }).slice(1, -1);
 					}
 				}
 			} catch (error) {
 				// Log error and continue with parsing the next variable
-				logger.error(`Could not parse variable ${varName}: ${varDump.join('\n')}`);
+				logger.error(`Could not parse variable ${originalExpression}: ${varDump.join('\n')}`);
 				this.consumeVarRef(threadId);
 				continue;
 			}
@@ -1321,10 +1606,21 @@ export class PerlDebugSession extends LoggingDebugSession {
 					} else {
 						const ref = this.consumeVarRef(threadId);
 						this.variableThreadMap.set(ref, threadId);
-						this.parseDumper(varDump.slice(1, -1), threadId, ref);
+						this.varExpressionMap.set(this.getScopedVarRef(threadId, ref), originalExpression);
+						this.varExpressionMap.set(this.getScopedVarRef(threadId, ref), originalExpression);
 						const matched = varDump[varDump.length - 1].trim().match(this.isVarEnd);
 						if (matched) {
 							const type = `${(matched[1] === '}' ? 'HASH' : 'ARRAY')}${(matched[3] ? ` ${matched[3]}` : '')}`;
+							const containerType = type.startsWith('HASH') ? 'HASH' : (type.startsWith('ARRAY') ? 'ARRAY' : undefined);
+							let total = 0;
+							if (containerType) {
+								total = await this.getContainerSize(originalExpression, containerType, threadId);
+								this.containerMetaMap.set(this.getScopedVarRef(threadId, ref), {
+									expression: originalExpression,
+									type: containerType,
+									total
+								});
+							}
 							const newVar: DebugProtocol.Variable = {
 								name: varNames[i],
 								value: type,
@@ -1332,10 +1628,10 @@ export class PerlDebugSession extends LoggingDebugSession {
 								evaluateName: varNames[i],
 								presentationHint: { kind: 'baseClass' }
 							};
-							if (type.startsWith('HASH')) {
-								newVar.namedVariables = this.childVarsMap.get(this.getScopedVarRef(threadId, ref))?.length;
-							} else if (type.startsWith('ARRAY')) {
-								newVar.indexedVariables = this.childVarsMap.get(this.getScopedVarRef(threadId, ref))?.length;
+							if (type.startsWith('HASH') && this.shouldExposeContainerCount('HASH', total)) {
+								newVar.namedVariables = total;
+							} else if (type.startsWith('ARRAY') && this.shouldExposeContainerCount('ARRAY', total)) {
+								newVar.indexedVariables = total;
 							}
 							vs.push(newVar);
 							this.parentVarsMap.set(this.getScopedVarRef(threadId, ref), newVar);
@@ -1383,7 +1679,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	private isNestedArray = /^(bless\(\s*)?(\{|\[)$/;
 	private isVarEnd = /^(\}|\]),?(\s?'(.*)'\s\))?[,|;]?/;
 	// Parse output of Data::Dumper
-	private parseDumper(lines: string[], threadId: number = PerlDebugSession.threadId, refOverride?: number): { parsedLines: number, varType: string, numChildVars: number; } {
+	private parseDumper(lines: string[], threadId: number = PerlDebugSession.threadId, refOverride?: number, parentExpression?: string): { parsedLines: number, varType: string, numChildVars: number; } {
 		let childVars: DebugProtocol.Variable[] = [];
 		let varType: string = '';
 		const ref: number = typeof refOverride === 'number' ? refOverride : this.consumeVarRef(threadId);
@@ -1400,72 +1696,75 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 			matched = trimmedLine.match(this.isNamedVariable);
 			if (matched) {
+				const childExpression = parentExpression ? this.buildNamedExpression(parentExpression, matched[1].replace(/"/, '')) : undefined;
 				childVars.push({
 					name: matched[1].replace(/"/, ''),
 					value: matched[2],
 					variablesReference: 0,
+					evaluateName: childExpression,
 					presentationHint: { kind: 'data' },
 					type: 'SCALAR'
 				});
-				if (childVars.length >= this.maxHashElements) {
-					break;
-				}
 				continue;
 			}
 			matched = trimmedLine.match(this.isNestedHash);
 			if (matched) {
 				const childRef = this.consumeVarRef(threadId);
 				const keyName = (matched[1] || '').replace(/^['"]|['"]$/g, '');
+				const openChar = matched[2];
+				const childExpression = parentExpression ? this.buildNamedExpression(parentExpression, keyName) : undefined;
 				const newVar: DebugProtocol.Variable = {
 					name: keyName,
-					value: '',
+					value: 'HASH',
+					type: 'HASH',
 					variablesReference: childRef,
+					evaluateName: childExpression,
 					presentationHint: { kind: 'innerClass' }
 				};
 				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
 				this.variableThreadMap.set(childRef, threadId);
-				const parsed = this.parseDumper(lines.slice(i + 1), threadId, childRef);
-				i += parsed.parsedLines;
-				newVar.value = parsed.varType;
-				newVar.type = parsed.varType;
-				newVar.namedVariables = parsed.numChildVars;
+				if (childExpression) {
+					this.varExpressionMap.set(this.getScopedVarRef(threadId, childRef), childExpression);
+				}
 				childVars.push(newVar);
+				i = this.skipNestedBlock(lines, i, openChar);
 				continue;
 			}
 			matched = trimmedLine.match(this.isIndexedVariable);
 			if (matched) {
+				const nextIndex = childVars.length;
+				const childExpression = parentExpression ? this.buildIndexedExpression(parentExpression, nextIndex) : undefined;
 				childVars.push({
-					name: `${childVars.length}`,
+					name: `${nextIndex}`,
 					value: matched[1],
 					variablesReference: 0,
+					evaluateName: childExpression,
 					presentationHint: { kind: 'data' },
 					type: 'SCALAR'
 				});
-				if (childVars.length >= this.maxArrayElements) {
-					break;
-				}
 				continue;
 			}
 			matched = trimmedLine.match(this.isNestedArray);
 			if (matched) {
 				const childRef = this.consumeVarRef(threadId);
+				const nextIndex = childVars.length;
+				const openChar = matched[2];
+				const childExpression = parentExpression ? this.buildIndexedExpression(parentExpression, nextIndex) : undefined;
 				const newVar: DebugProtocol.Variable = {
-					name: `${childVars.length}`,
-					value: '',
+					name: `${nextIndex}`,
+					value: 'ARRAY',
+					type: 'ARRAY',
 					variablesReference: childRef,
+					evaluateName: childExpression,
 					presentationHint: { kind: 'innerClass' }
 				};
 				this.parentVarsMap.set(this.getScopedVarRef(threadId, childRef), newVar);
 				this.variableThreadMap.set(childRef, threadId);
-				const parsed = this.parseDumper(lines.slice(i + 1), threadId, childRef);
-				i += parsed.parsedLines;
-				newVar.value = parsed.varType;
-				newVar.type = parsed.varType;
-				newVar.indexedVariables = parsed.numChildVars;
-				childVars.push(newVar);
-				if (childVars.length >= this.maxArrayElements) {
-					break;
+				if (childExpression) {
+					this.varExpressionMap.set(this.getScopedVarRef(threadId, childRef), childExpression);
 				}
+				childVars.push(newVar);
+				i = this.skipNestedBlock(lines, i, openChar);
 				continue;
 			}
 			if (line.trim() !== '') {
@@ -1478,21 +1777,55 @@ export class PerlDebugSession extends LoggingDebugSession {
 				});
 			}
 		}
-		this.childVarsMap.set(this.getScopedVarRef(threadId, ref), childVars);
+		let finalChildren = childVars;
+		const chunkSize = varType.startsWith('HASH') ? this.maxHashElements : this.maxArrayElements;
+		if (chunkSize > 0 && childVars.length > chunkSize) {
+			const chunks: DebugProtocol.Variable[] = [];
+			for (let start = 0; start < childVars.length; start += chunkSize) {
+				const end = Math.min(start + chunkSize, childVars.length);
+				const chunkRef = this.consumeVarRef(threadId);
+				this.variableThreadMap.set(chunkRef, threadId);
+				this.childVarsMap.set(this.getScopedVarRef(threadId, chunkRef), childVars.slice(start, end));
+				chunks.push({
+					name: varType.startsWith('HASH') ? `[keys ${start}..${end - 1}]` : `[${start}..${end - 1}]`,
+					value: `${varType} CHUNK`,
+					type: varType.startsWith('HASH') ? 'HASH' : 'ARRAY',
+					variablesReference: chunkRef,
+					presentationHint: { kind: 'data' }
+				});
+			}
+			finalChildren = chunks;
+		}
+
+		this.childVarsMap.set(this.getScopedVarRef(threadId, ref), finalChildren);
 		const parsedLines = i < lines.length ? i + 1 : i;
 		return { parsedLines: parsedLines, varType: varType, numChildVars: childVars.length };
 	}
 
 	protected async setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): Promise<void> {
 		const threadId = this.variableThreadMap.get(args.variablesReference) || this.currentStoppedThreadId;
-		const expressionToChange = this.getExpression(args.variablesReference, args.name, threadId);
+		const scopedRef = this.getScopedVarRef(threadId, args.variablesReference);
+		let loadedChildren = this.childVarsMap.get(scopedRef) || [];
+		let loadedChild = loadedChildren.find((entry) => entry.name === args.name) as DebugProtocol.Variable | undefined;
+		if (!loadedChild) {
+			const refreshedChildren = await this.loadContainerChildren(args.variablesReference, threadId);
+			if (refreshedChildren) {
+				loadedChildren = refreshedChildren;
+				loadedChild = loadedChildren.find((entry) => entry.name === args.name) as DebugProtocol.Variable | undefined;
+			}
+		}
+		const expressionToChange = loadedChild?.evaluateName || this.getExpression(args.variablesReference, args.name, threadId);
 		const lines = (await this.request(`${expressionToChange} = ${args.value}`, threadId)).filter(e => { return e !== ''; });
-		if (lines.slice(1, -1).length > 0) {
+		if (this.hasDebuggerCommandError(lines)) {
 			this.logSendEvent(new OutputEvent(`Error setting value: ${lines.join(' ')}`, 'important'));
 			response.success = false;
 		} else {
-			const value = (await this.request(`print STDERR Data::Dumper->new([${(expressionToChange.startsWith('@') ? `[${expressionToChange}]` : (expressionToChange.startsWith('%') ? `{${expressionToChange}}` : expressionToChange))}], [])->Useqq(1)->Terse(1)->Dump()`, threadId)).slice(1, -1).join(' ');
-			response.body = { value: `${value.trim()}` };
+			const value = this.extractCommandPayload(await this.request(this.buildOutputPrintCommand(`Data::Dumper->new([${(expressionToChange.startsWith('@') ? `[${expressionToChange}]` : (expressionToChange.startsWith('%') ? `{${expressionToChange}}` : expressionToChange))}], [])->Useqq(1)->Terse(1)->Dump()`), threadId)).join(' ');
+			const trimmedValue = value.trim();
+			if (loadedChild) {
+				loadedChild.value = trimmedValue;
+			}
+			response.body = { value: `${trimmedValue}` };
 		}
 		this.logSendResponse(response);
 	}
@@ -1502,7 +1835,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		const runtimes = Array.from(this.runtimes.values());
 		for (let i = 0; i < runtimes.length; i++) {
 			const runtime = runtimes[i];
-			const lines = await this.request('foreach my $INCKEY (keys %INC) { print STDERR "$INCKEY||$INC{$INCKEY}\\n" }', runtime.threadId);
+			const lines = await this.request(`foreach my $INCKEY (keys %INC) { ${this.buildOutputPrintCommand('"$INCKEY||$INC{$INCKEY}\\n"')} }`, runtime.threadId);
 			// remove first and last line
 			lines.filter(e => { return e !== ''; }).slice(1, -1).forEach(line => {
 				const tmp = line.split('||');

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -458,21 +458,28 @@ export class PerlDebugSession extends LoggingDebugSession {
 	 * Changes the file context inside the perl5db-process.
 	 */
 	private async changeFileContext(filePath: string, threadId: number = PerlDebugSession.threadId): Promise<string | undefined> {
-		let formattedPath = filePath
-			.replace(/\\{1,2}/g, '/')
-			.replace(/^\.\.\/+/g, '');
-		let data = (await this.request(`f ${formattedPath}`, threadId))[1];
-		if (data.match(/^No file matching '.*' is loaded./)) {
-			logger.log(`Could not change file context: ${data}`);
-			formattedPath = basename(formattedPath);
-			data = (await this.request(`f ${formattedPath}`, threadId))[1];
-			if (data.match(/^No file matching '.*' is loaded./)) {
-				logger.log(`Could not change file context: ${data}`);
-				return undefined;
+		const normalizedPath = this.normalizePathAndCasing(filePath).replace(/^\.\.\/+/g, '');
+		const candidates = Array.from(new Set([
+			basename(normalizedPath),
+			normalizedPath,
+			normalizedPath.replace(/\\{1,2}/g, '/')
+		].filter((candidate) => candidate.length > 0)));
+
+		let lastError = '';
+		for (let i = 0; i < candidates.length; i++) {
+			const candidate = candidates[i];
+			const data = (await this.request(`f ${candidate}`, threadId))[1];
+			if (!data.match(/^No file matching '.*' is loaded./)) {
+				logger.log(`Successfully changed file context to ${candidate}: ${data}`);
+				return candidate;
 			}
+			lastError = data;
 		}
-		logger.log(`Successfully changed file context to ${formattedPath}: ${data}`);
-		return formattedPath;
+
+		if (lastError) {
+			logger.log(`Could not change file context: ${lastError}`);
+		}
+		return undefined;
 	}
 
 	/**

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -761,6 +761,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 		const keysSource = parentExpression.startsWith('%')
 			? `keys ${parentExpression}`
 			: `do { my $__h = ${this.normalizeExpressionForContainer(parentExpression)}; keys %{$__h} }`;
+		if (!this.sortKeys) {
+			return `do { my @k = ${keysSource}; @k[${start}..${end}] }`;
+		}
 		return `do { my @k = ${keysSource}; my $all_numeric = 1; for my $k (@k) { if ($k !~ /^-?\\d+$/) { $all_numeric = 0; last; } } @k = $all_numeric ? sort { $a <=> $b } @k : sort { $a cmp $b } @k; @k[${start}..${end}] }`;
 	}
 

--- a/src/tests/data/.vscode/launch.json
+++ b/src/tests/data/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "perl",
+            "request": "launch",
+            "name": "Perl Debug",
+            "program": "${workspaceFolder}/${relativeFile}",
+            "stopOnEntry": false,
+            // "trace": true,
+            // "maxArrayElements": 10,
+            // "maxHashElements": 10,
+            // "sortKeys": true,
+            // "perlExecutable": "C:\\berrybrew\\instance\\5.10.1_32\\perl\\bin\\perl.exe"
+        },
+        {
+            "type": "perl",
+            "request": "launch",
+            "name": "Perl Debug Fork Socket Manual",
+            "program": "${workspaceFolder}/fork_socket_manual.pl",
+            "transport": "socket",
+            "trace": true
+        }
+    ]
+}

--- a/src/tests/data/fork_socket_manual.pl
+++ b/src/tests/data/fork_socket_manual.pl
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use Time::HiRes qw(usleep);
+
+require './dbconfig.pl';
+test('pre-fork setup');
+
+sub compute_value {
+    my ($base) = @_;
+    my $value = $base;
+    $value += 3;
+    $value *= 2;
+    return $value;
+}
+
+print "starting parent pid=$$\n";
+
+my $pid = fork();
+if (!defined $pid) {
+    die "fork failed: $!\n";
+}
+
+if ($pid == 0) {
+    my $child_value = compute_value(2);
+
+    print "child attached\n";
+
+    for my $i (1 .. 5) {
+        $child_value += $i;
+        my $child_hash = {
+            index => $i,
+            value => $child_value,
+            role  => 'child'
+        };
+        print "child loop i=$i value=$child_hash->{value}\n";
+        usleep(200_000);
+    }
+
+    my @child_list = ('alpha', 'beta', 'gamma');
+    print "child done count=" . scalar(@child_list) . "\n";
+    exit 0;
+}
+
+my $parent_value = compute_value(10);
+print "parent attached\n";
+
+for my $j (1 .. 5) {
+    $parent_value += $j;
+    my %parent_hash = (
+        index => $j,
+        value => $parent_value,
+        role  => 'parent'
+    );
+    print "parent loop j=$j value=$parent_hash{value}\n";
+    usleep(150_000);
+}
+
+waitpid($pid, 0);
+my @parent_list = (1, 2, 3, 4);
+print "parent done count=" . scalar(@parent_list) . "\n";

--- a/src/tests/debugAdapter.test.ts
+++ b/src/tests/debugAdapter.test.ts
@@ -180,3 +180,729 @@ describe('Perl Debug Adapter', () => {
 		});
 	});
 });
+
+describe('PerlDebugSession fork handling', () => {
+	let session: any;
+	let events: any[];
+
+	beforeEach(() => {
+		const { PerlDebugSession } = require('../perlDebug');
+		session = new PerlDebugSession();
+		events = [];
+		session.sendEvent = (event: any) => {
+			events.push(event);
+		};
+		session._session = {
+			killed: false,
+			kill: jest.fn(() => true)
+		};
+	});
+
+	test('terminates unsupported forked sessions to avoid corrupted state', () => {
+		session.handleSessionOutput('Forked, but do not know how to create a new TTY', 'stderr');
+
+		expect(session._session.kill).toHaveBeenCalledTimes(1);
+		expect(events.some((event) => event.event === 'terminated')).toBe(true);
+		expect(events.some((event) => event.event === 'output' && event.body.category === 'important' && event.body.output.includes('not supported by this adapter'))).toBe(true);
+	});
+
+	test('forwards normal process output without terminating the session', () => {
+		session.handleSessionOutput('hello from perl\n', 'stdout');
+
+		expect(session._session.kill).not.toHaveBeenCalled();
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe('output');
+		expect(events[0].body.category).toBe('stdout');
+		expect(events[0].body.output).toBe('hello from perl\n');
+	});
+});
+
+describe('PerlDebugSession launch transport setup', () => {
+	const PROJECT_ROOT = Path.dirname(__dirname);
+	const CWD = Path.join(PROJECT_ROOT, 'tests', 'data');
+	const PERL_SCRIPT = Path.join(CWD, 'test.pl');
+
+	afterEach(() => {
+		jest.resetModules();
+		jest.restoreAllMocks();
+		jest.clearAllMocks();
+	});
+
+	function createMockChildProcess() {
+		const stdoutHandlers = new Map<string, Function[]>();
+		const stderrHandlers = new Map<string, Function[]>();
+		const processHandlers = new Map<string, Function[]>();
+		const stdout: any = {
+			on: jest.fn((event: string, handler: Function): any => {
+				const handlers = stdoutHandlers.get(event) || [];
+				handlers.push(handler);
+				stdoutHandlers.set(event, handlers);
+				return stdout;
+			})
+		};
+
+		const stderr: any = {
+			on: jest.fn((event: string, handler: Function): any => {
+				const handlers = stderrHandlers.get(event) || [];
+				handlers.push(handler);
+				stderrHandlers.set(event, handlers);
+				return stderr;
+			})
+		};
+
+		const child: any = {
+			stdin: {},
+			stdout,
+			stderr,
+			killed: false,
+			kill: jest.fn(() => true),
+			on: jest.fn((event: string, handler: Function) => {
+				const handlers = processHandlers.get(event) || [];
+				handlers.push(handler);
+				processHandlers.set(event, handlers);
+				return child;
+			})
+		};
+
+		return child;
+	}
+
+	function createMockSocketServer(onConnection: Function | undefined, socket: any) {
+		const listeners = new Map<string, Function[]>();
+
+		const server: any = {
+			on: jest.fn((event: string, handler: Function) => {
+				const handlers = listeners.get(event) || [];
+				handlers.push(handler);
+				listeners.set(event, handlers);
+				return server;
+			}),
+			once: jest.fn((event: string, handler: Function) => {
+				const wrapped = (...args: any[]) => {
+					server.off(event, wrapped);
+					handler(...args);
+				};
+				return server.on(event, wrapped);
+			}),
+			off: jest.fn((event: string, handler: Function) => {
+				const handlers = listeners.get(event) || [];
+				listeners.set(event, handlers.filter((entry) => entry !== handler));
+				return server;
+			}),
+			emit: (event: string, ...args: any[]) => {
+				if (event === 'connection' && onConnection) {
+					onConnection(...args);
+				}
+				const handlers = listeners.get(event) || [];
+				handlers.forEach((handler) => handler(...args));
+			},
+			listen: jest.fn((_port: number, _host: string, callback: Function) => {
+				callback();
+				setImmediate(() => {
+					server.emit('connection', socket);
+				});
+				return server;
+			}),
+			address: jest.fn(() => ({ address: '127.0.0.1', family: 'IPv4', port: 43123 })),
+			close: jest.fn()
+		};
+
+		return server;
+	}
+
+	function createMockDuplexSocket() {
+		const listeners = new Map<string, Function[]>();
+		const socket: any = {
+			destroyed: false,
+			on: jest.fn((event: string, handler: Function) => {
+				const handlers = listeners.get(event) || [];
+				handlers.push(handler);
+				listeners.set(event, handlers);
+				return socket;
+			}),
+			once: jest.fn((event: string, handler: Function) => {
+				const wrapped = (...args: any[]) => {
+					socket.off(event, wrapped);
+					handler(...args);
+				};
+				socket.on(event, wrapped);
+				return socket;
+			}),
+			off: jest.fn((event: string, handler: Function) => {
+				const handlers = listeners.get(event) || [];
+				listeners.set(event, handlers.filter((entry) => entry !== handler));
+				return socket;
+			}),
+			write: jest.fn(() => true),
+			destroy: jest.fn(() => {
+				socket.destroyed = true;
+				socket.emit('close');
+			}),
+			emit: (event: string, ...args: any[]) => {
+				const handlers = listeners.get(event) || [];
+				handlers.forEach((handler) => handler(...args));
+			}
+		};
+
+		return socket;
+	}
+
+	function createLaunchResponse() {
+		return {
+			seq: 1,
+			type: 'response',
+			request_seq: 1,
+			command: 'launch',
+			success: true
+		} as any;
+	}
+
+	function createLaunchArgs(overrides: Record<string, unknown> = {}) {
+		return {
+			program: PERL_SCRIPT,
+			stopOnEntry: true,
+			cwd: CWD,
+			debug: true,
+			type: 'perl',
+			request: 'launch',
+			name: 'Perl Debug',
+			...overrides
+		} as any;
+	}
+
+	test('uses stdio transport by default', async () => {
+		jest.resetModules();
+
+		const child = createMockChildProcess();
+		const spawnMock = jest.fn(() => child);
+		const createServerMock = jest.fn();
+
+		jest.doMock('child_process', () => ({
+			...jest.requireActual('child_process'),
+			spawn: spawnMock
+		}));
+		jest.doMock('net', () => ({
+			...jest.requireActual('net'),
+			createServer: createServerMock
+		}));
+
+		const { PerlDebugSession } = require('../perlDebug');
+		const session = new PerlDebugSession();
+		(session as any).streamCatcher = { launch: jest.fn().mockResolvedValue([]), getBuffer: jest.fn(() => []), request: jest.fn() };
+		jest.spyOn(session as any, 'request').mockResolvedValue(['ok']);
+		session.sendEvent = jest.fn();
+		(session as any).logSendResponse = jest.fn();
+
+		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs());
+
+		expect(createServerMock).not.toHaveBeenCalled();
+		expect(spawnMock).toHaveBeenCalledWith(
+			'perl',
+			expect.any(Array),
+			expect.objectContaining({
+				env: expect.objectContaining({
+					PERLDB_OPTS: 'ReadLine=0'
+				})
+			})
+		);
+		expect((session as any).streamCatcher.launch).toHaveBeenCalledWith(child.stdin, child.stderr);
+	});
+
+	test('uses socket transport when requested', async () => {
+		jest.resetModules();
+
+		const child = createMockChildProcess();
+		const socket = { destroyed: false, destroy: jest.fn() };
+		let server: any;
+		const spawnMock = jest.fn(() => child);
+		const createServerMock = jest.fn((onConnection: Function) => {
+			server = createMockSocketServer(onConnection, socket);
+			return server;
+		});
+
+		jest.doMock('child_process', () => ({
+			...jest.requireActual('child_process'),
+			spawn: spawnMock
+		}));
+		jest.doMock('net', () => ({
+			...jest.requireActual('net'),
+			createServer: createServerMock
+		}));
+
+		const { PerlDebugSession } = require('../perlDebug');
+		const session = new PerlDebugSession();
+		(session as any).streamCatcher = { launch: jest.fn().mockResolvedValue([]), getBuffer: jest.fn(() => []), request: jest.fn() };
+		jest.spyOn(session as any, 'request').mockResolvedValue(['ok']);
+		session.sendEvent = jest.fn();
+		(session as any).logSendResponse = jest.fn();
+
+		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs({ transport: 'socket' }));
+
+		expect(createServerMock).toHaveBeenCalledTimes(1);
+		expect(spawnMock).toHaveBeenCalledWith(
+			'perl',
+			expect.any(Array),
+			expect.objectContaining({
+				env: expect.objectContaining({
+					PERLDB_OPTS: 'ReadLine=0 RemotePort=127.0.0.1:43123'
+				})
+			})
+		);
+		expect((session as any).streamCatcher.launch).toHaveBeenCalledWith(socket, socket);
+	});
+
+	test('maps additional socket connections to managed child thread runtimes', async () => {
+		jest.resetModules();
+
+		const child = createMockChildProcess();
+		const primarySocket = createMockDuplexSocket();
+		let server: any;
+		const spawnMock = jest.fn(() => child);
+		const createServerMock = jest.fn((onConnection: Function) => {
+			server = createMockSocketServer(onConnection, primarySocket);
+			return server;
+		});
+
+		jest.doMock('child_process', () => ({
+			...jest.requireActual('child_process'),
+			spawn: spawnMock
+		}));
+		jest.doMock('net', () => ({
+			...jest.requireActual('net'),
+			createServer: createServerMock
+		}));
+
+		const { PerlDebugSession } = require('../perlDebug');
+		const session = new PerlDebugSession();
+		(session as any).streamCatcher = { launch: jest.fn().mockResolvedValue([]), getBuffer: jest.fn(() => []), request: jest.fn() };
+		jest.spyOn(session as any, 'request').mockResolvedValue(['ok']);
+		session.sendEvent = jest.fn();
+		(session as any).logSendResponse = jest.fn();
+
+		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs({ transport: 'socket' }));
+
+		const childSocket = createMockDuplexSocket();
+		server.emit('connection', childSocket);
+		childSocket.emit('data', Buffer.from('DB<1>\n'));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(childSocket.destroy).not.toHaveBeenCalled();
+
+		const sentEvents = (session.sendEvent as jest.Mock).mock.calls.map((call) => call[0]);
+		const threadEvents = sentEvents.filter((event) => event.event === 'thread');
+		expect(threadEvents.some((event) => event.body.reason === 'started')).toBe(true);
+		expect(sentEvents.some((event) => event.event === 'output' && event.body.category === 'important' && event.body.output.includes('Attached forked perl5db child transport'))).toBe(true);
+
+		const threadsResponse: any = {
+			seq: 2,
+			type: 'response',
+			request_seq: 2,
+			command: 'threads',
+			success: true
+		};
+		(session as any).logSendResponse = jest.fn();
+		await (session as any).threadsRequest(threadsResponse);
+		expect(threadsResponse.body.threads.some((thread: any) => thread.id === 2)).toBe(true);
+	});
+
+	test('sends launch response before initial stopped event on stopOnEntry', async () => {
+		jest.resetModules();
+
+		const child = createMockChildProcess();
+		const spawnMock = jest.fn(() => child);
+		const createServerMock = jest.fn();
+
+		jest.doMock('child_process', () => ({
+			...jest.requireActual('child_process'),
+			spawn: spawnMock
+		}));
+		jest.doMock('net', () => ({
+			...jest.requireActual('net'),
+			createServer: createServerMock
+		}));
+
+		const { PerlDebugSession } = require('../perlDebug');
+		const session = new PerlDebugSession();
+		(session as any).streamCatcher = { launch: jest.fn().mockResolvedValue([]), getBuffer: jest.fn(() => []), request: jest.fn() };
+		jest.spyOn(session as any, 'request').mockResolvedValue(['ok']);
+		session.sendEvent = jest.fn();
+		(session as any).logSendResponse = jest.fn();
+
+		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs({ stopOnEntry: true }));
+
+		const events = (session.sendEvent as jest.Mock).mock.calls.map((call) => call[0]);
+		const stoppedIndex = events.findIndex((event) => event.event === 'stopped' && event.body.reason === 'entry');
+		expect(stoppedIndex).toBeGreaterThanOrEqual(0);
+
+		const stoppedCallOrder = (session.sendEvent as jest.Mock).mock.invocationCallOrder[stoppedIndex];
+		const responseCallOrder = (session as any).logSendResponse.mock.invocationCallOrder[0];
+		expect(responseCallOrder).toBeLessThan(stoppedCallOrder);
+	});
+});
+
+describe('PerlDebugSession thread-aware routing', () => {
+	let session: any;
+
+	function createThreadAwareMockSocket() {
+		const listeners = new Map<string, Function[]>();
+		const socket: any = {
+			destroyed: false,
+			on: jest.fn((event: string, handler: Function) => {
+				const handlers = listeners.get(event) || [];
+				handlers.push(handler);
+				listeners.set(event, handlers);
+				return socket;
+			}),
+			once: jest.fn((event: string, handler: Function) => {
+				const wrapped = (...args: any[]) => {
+					socket.off(event, wrapped);
+					handler(...args);
+				};
+				socket.on(event, wrapped);
+				return socket;
+			}),
+			off: jest.fn((event: string, handler: Function) => {
+				const handlers = listeners.get(event) || [];
+				listeners.set(event, handlers.filter((entry) => entry !== handler));
+				return socket;
+			}),
+			write: jest.fn(() => true),
+			destroy: jest.fn(() => {
+				socket.destroyed = true;
+				socket.emit('close');
+			}),
+			emit: (event: string, ...args: any[]) => {
+				const handlers = listeners.get(event) || [];
+				handlers.forEach((handler) => handler(...args));
+			}
+		};
+
+		return socket;
+	}
+
+	beforeEach(() => {
+		jest.resetModules();
+		const { PerlDebugSession } = require('../perlDebug');
+		session = new PerlDebugSession();
+		session.sendEvent = jest.fn();
+		session.logSendResponse = jest.fn();
+		session.request = jest.fn().mockResolvedValue([
+			'T',
+			'@ = main::test called from file \'./test.pl\' line 7',
+			'DB<1>'
+		]);
+		session.parseVars = jest.fn().mockResolvedValue([
+			{ name: '$x', value: '1', variablesReference: 0, evaluateName: '$x', presentationHint: { kind: 'data' }, type: 'SCALAR' }
+		]);
+		session.getExpression = jest.fn().mockReturnValue('$x');
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+		jest.clearAllMocks();
+	});
+
+	test('routes stackTrace request to selected thread runtime', async () => {
+		const response: any = { seq: 1, type: 'response', request_seq: 1, command: 'stackTrace', success: true };
+		await session.stackTraceRequest(response, { threadId: 2 } as any);
+
+		expect(session.request).toHaveBeenCalledWith('T', 2);
+		expect(response.body.stackFrames.length).toBeGreaterThan(0);
+	});
+
+	test('parses alternate at-format stack lines to keep source location visible', async () => {
+		session.request = jest.fn().mockResolvedValue([
+			'T',
+			'main::worker at ./fork_socket_manual.pl line 44.',
+			'DB<1>'
+		]);
+
+		const response: any = { seq: 11, type: 'response', request_seq: 11, command: 'stackTrace', success: true };
+		await session.stackTraceRequest(response, { threadId: 1 } as any);
+
+		expect(response.body.stackFrames.length).toBeGreaterThan(0);
+		expect(response.body.stackFrames[0].source.path.endsWith('fork_socket_manual.pl')).toBe(true);
+		expect(response.body.stackFrames[0].line).toBe(44);
+	});
+
+	test('routes scope variables request to thread from frame context', async () => {
+		const scopesResponse: any = { seq: 2, type: 'response', request_seq: 2, command: 'scopes', success: true };
+		session.frameThreadMap.set(77, 2);
+		session.request = jest.fn().mockResolvedValue(['cmd', '', 'DB<1>']);
+
+		session.scopesRequest(scopesResponse, { frameId: 77 } as any);
+		const myScopeRef = scopesResponse.body.scopes[0].variablesReference;
+
+		const varsResponse: any = { seq: 3, type: 'response', request_seq: 3, command: 'variables', success: true };
+		await session.variablesRequest(varsResponse, { variablesReference: myScopeRef } as any);
+
+		expect(session.request).toHaveBeenCalledWith('print STDERR join ("|", sort(keys( % { PadWalker::peek_my(2); })))', 2);
+	});
+
+	test('routes evaluate request to frame thread', async () => {
+		const response: any = { seq: 4, type: 'response', request_seq: 4, command: 'evaluate', success: true };
+		session.frameThreadMap.set(99, 2);
+
+		await session.evaluateRequest(response, { expression: '$x', frameId: 99 } as any);
+
+		expect(session.parseVars).toHaveBeenCalledWith(['$x'], 2);
+	});
+
+	test('routes setVariable request using variablesReference thread mapping', async () => {
+		const response: any = { seq: 5, type: 'response', request_seq: 5, command: 'setVariable', success: true };
+		session.variableThreadMap.set(123, 2);
+		session.request = jest.fn().mockResolvedValue(['cmd', 'DB<1>']);
+
+		await session.setVariableRequest(response, {
+			variablesReference: 123,
+			name: 'x',
+			value: '2'
+		} as any);
+
+		expect(session.getExpression).toHaveBeenCalledWith(123, 'x', 2);
+		expect((session.request as jest.Mock).mock.calls[0][1]).toBe(2);
+	});
+
+	test('rejects duplicate continue while same thread execution command is in-flight', () => {
+		session.continue = jest.fn(() => new Promise<void>(() => { return; }));
+
+		const firstResponse: any = { seq: 50, type: 'response', request_seq: 50, command: 'continue', success: true };
+		const secondResponse: any = { seq: 51, type: 'response', request_seq: 51, command: 'continue', success: true };
+
+		session.continueRequest(firstResponse, { threadId: 1 } as any);
+		session.continueRequest(secondResponse, { threadId: 1 } as any);
+
+		expect(session.continue).toHaveBeenCalledTimes(1);
+		expect(secondResponse.success).toBe(false);
+		const events = (session.sendEvent as jest.Mock).mock.calls.map((call) => call[0]);
+		const continuedEvents = events.filter((event) => event.event === 'continued' && event.body.threadId === 1);
+		expect(continuedEvents.length).toBe(1);
+		expect(continuedEvents[0].body.allThreadsContinued).toBe(false);
+		expect(events.some((event) => event.event === 'output' && event.body.output.includes('Ignored continue request'))).toBe(true);
+	});
+
+	test('auto-continues continue-stop when current location has no runtime line breakpoint', async () => {
+		session.funcBps = [];
+		session.request = jest.fn().mockResolvedValue([
+			'c',
+			'main::(./dbconfig.pl:4):',
+			'DB<11>'
+		]);
+		session.getStackFrames = jest.fn().mockResolvedValue([
+			{ line: 4, source: { path: 'C:\\repo\\dbconfig.pl' } }
+		]);
+		session.runtimeBreakpointsMap.set(1, new Map([
+			['C:\\repo\\fork_socket_manual.pl', [{ id: 1, line: 47, condition: '' }]]
+		]));
+		session.continue = jest.fn().mockResolvedValue(undefined);
+
+		await session.execute('c', 1);
+
+		expect(session.continue).toHaveBeenCalledWith(1);
+		const events = (session.sendEvent as jest.Mock).mock.calls.map((call) => call[0]);
+		expect(events.some((event) => event.event === 'stopped')).toBe(false);
+	});
+
+	test('synchronizes function breakpoints across all active runtimes', async () => {
+		session.streamCatcher.input = {};
+		session.runtimes.set(1, { threadId: 1, name: 'thread 1', streamCatcher: {}, isPrimary: true });
+		session.runtimes.set(2, { threadId: 2, name: 'thread 2', streamCatcher: {}, isPrimary: false });
+		session.request = jest.fn().mockResolvedValue(['cmd', 'ok', 'DB<1>']);
+
+		const response: any = { seq: 6, type: 'response', request_seq: 6, command: 'setFunctionBreakpoints', success: true };
+		await session.setFunctionBreakPointsRequest(response, {
+			breakpoints: [{ name: 'My::func', condition: '1' }]
+		} as any);
+
+		expect(session.request).toHaveBeenCalledWith('b My::func 1', 1);
+		expect(session.request).toHaveBeenCalledWith('b My::func 1', 2);
+	});
+
+	test('aggregates loaded sources from all runtimes', async () => {
+		session.runtimes.set(1, { threadId: 1, name: 'thread 1', streamCatcher: {}, isPrimary: true });
+		session.runtimes.set(2, { threadId: 2, name: 'thread 2', streamCatcher: {}, isPrimary: false });
+		session.request = jest.fn(async (_cmd: string, threadId: number) => {
+			if (threadId === 1) {
+				return ['cmd', 'Foo.pm||./lib/Foo.pm', 'DB<1>'];
+			}
+			return ['cmd', 'Bar.pm||./lib/Bar.pm', 'Foo.pm||./lib/Foo.pm', 'DB<1>'];
+		});
+
+		const response: any = { seq: 7, type: 'response', request_seq: 7, command: 'loadedSources', success: true };
+		await session.loadedSourcesRequest(response, {} as any);
+
+		expect(session.request).toHaveBeenCalledWith('foreach my $INCKEY (keys %INC) { print STDERR "$INCKEY||$INC{$INCKEY}\\n" }', 1);
+		expect(session.request).toHaveBeenCalledWith('foreach my $INCKEY (keys %INC) { print STDERR "$INCKEY||$INC{$INCKEY}\\n" }', 2);
+		expect(response.body.sources.length).toBe(2);
+	});
+
+	test('syncRuntimeBreakpoints mirrors file and function breakpoints to a child runtime', async () => {
+		session.desiredBreakpointsMap.set('C:\\repo\\test.pl', [{ id: 1, line: 10, condition: '1' }]);
+		session.funcBps = [{ name: 'My::func', condition: '1' }];
+		session.changeFileContext = jest.fn().mockResolvedValue('test.pl');
+		session.request = jest.fn().mockResolvedValue(['cmd', 'ok', 'DB<1>']);
+		session.runtimeBreakpointsMap.set(2, new Map());
+		session.runtimePostponedBreakpointsMap.set(2, new Map());
+
+		await session.syncRuntimeBreakpoints(2);
+
+		expect(session.changeFileContext).toHaveBeenCalledWith('C:\\repo\\test.pl', 2);
+		expect(session.request).toHaveBeenCalledWith('b 10 1', 2);
+		expect(session.request).toHaveBeenCalledWith('b My::func 1', 2);
+	});
+
+	test('applyBreakpointsToRuntime keeps unresolved breakpoints in runtime-postponed map', async () => {
+		session.changeFileContext = jest.fn().mockResolvedValue(undefined);
+		session.runtimePostponedBreakpointsMap.set(2, new Map());
+
+		await session.applyBreakpointsToRuntime('C:\\repo\\late.pl', [{ id: 1, line: 11, condition: '1' }], 2);
+
+		expect(session.runtimePostponedBreakpointsMap.get(2).get('C:\\repo\\late.pl')).toEqual([{ id: 1, line: 11, condition: '1' }]);
+	});
+
+	test('setBreakPointsRequest stores postponed breakpoints for each active runtime', async () => {
+		session.streamCatcher.input = {};
+		session.runtimes.set(1, { threadId: 1, name: 'thread 1', streamCatcher: {}, isPrimary: true });
+		session.runtimes.set(2, { threadId: 2, name: 'thread 2', streamCatcher: {}, isPrimary: false });
+		session.runtimePostponedBreakpointsMap.set(1, new Map());
+		session.runtimePostponedBreakpointsMap.set(2, new Map());
+		session.changeFileContext = jest.fn().mockResolvedValue(undefined);
+
+		const response: any = { seq: 8, type: 'response', request_seq: 8, command: 'setBreakpoints', success: true };
+		await session.setBreakPointsRequest(response, {
+			source: { path: 'C:\\repo\\late.pl' },
+			breakpoints: [{ line: 33, condition: '1' }]
+		} as any);
+
+		expect(session.runtimePostponedBreakpointsMap.get(1).has('C:\\repo\\late.pl')).toBe(true);
+		expect(session.runtimePostponedBreakpointsMap.get(2).has('C:\\repo\\late.pl')).toBe(true);
+	});
+
+	test('runtime postponed overlays are cloned from desired state', () => {
+		session.desiredPostponedBreakpointsMap.set('C:\\repo\\late.pl', [{ id: 1, line: 11, condition: '1' }]);
+
+		const runtimePostponed = session.getRuntimePostponedBreakpoints(2);
+		runtimePostponed.get('C:\\repo\\late.pl')[0].line = 99;
+
+		expect(session.desiredPostponedBreakpointsMap.get('C:\\repo\\late.pl')[0].line).toBe(11);
+	});
+
+	test('applyBreakpointsToRuntime unresolved updates runtime overlay only', async () => {
+		session.desiredPostponedBreakpointsMap.set('C:\\repo\\late.pl', [{ id: 1, line: 11, condition: '1' }]);
+		session.changeFileContext = jest.fn().mockResolvedValue(undefined);
+
+		await session.applyBreakpointsToRuntime('C:\\repo\\late.pl', [{ id: 2, line: 22, condition: '2' }], 2);
+
+		expect(session.runtimePostponedBreakpointsMap.get(2).get('C:\\repo\\late.pl')).toEqual([{ id: 2, line: 22, condition: '2' }]);
+		expect(session.desiredPostponedBreakpointsMap.get('C:\\repo\\late.pl')).toEqual([{ id: 1, line: 11, condition: '1' }]);
+	});
+
+	test('clearThreadScopedState removes per-thread frames variables and runtime overlays', () => {
+		session.currentStoppedThreadId = 2;
+		session.frameThreadMap.set(100, 2);
+		session.frameThreadMap.set(101, 1);
+		session.variableThreadMap.set(123, 2);
+		session.variableThreadMap.set(124, 1);
+		session.threadVarRef.set(2, 995);
+		session.threadVarRef.set(1, 999);
+		session.childVarsMap.set(200999, [{ name: '$x', value: '1', variablesReference: 0 }]);
+		session.childVarsMap.set(100999, [{ name: '$y', value: '2', variablesReference: 0 }]);
+		session.parentVarsMap.set(200999, { name: '$x', value: '1', variablesReference: 0 });
+		session.parentVarsMap.set(100999, { name: '$y', value: '2', variablesReference: 0 });
+		session.runtimeBreakpointsMap.set(2, new Map([['C:\\repo\\x.pl', [{ id: 1, line: 5, condition: '' }]]]));
+		session.runtimeBreakpointsMap.set(1, new Map([['C:\\repo\\x.pl', [{ id: 2, line: 6, condition: '' }]]]));
+		session.runtimePostponedBreakpointsMap.set(2, new Map([['C:\\repo\\x.pl', [{ id: 3, line: 7, condition: '' }]]]));
+		session.runtimePostponedBreakpointsMap.set(1, new Map([['C:\\repo\\x.pl', [{ id: 4, line: 8, condition: '' }]]]));
+
+		session.clearThreadScopedState(2);
+
+		expect(session.frameThreadMap.has(100)).toBe(false);
+		expect(session.frameThreadMap.has(101)).toBe(true);
+		expect(session.variableThreadMap.has(123)).toBe(false);
+		expect(session.variableThreadMap.has(124)).toBe(true);
+		expect(session.threadVarRef.has(2)).toBe(false);
+		expect(session.threadVarRef.has(1)).toBe(true);
+		expect(session.childVarsMap.has(200999)).toBe(false);
+		expect(session.childVarsMap.has(100999)).toBe(true);
+		expect(session.parentVarsMap.has(200999)).toBe(false);
+		expect(session.parentVarsMap.has(100999)).toBe(true);
+		expect(session.runtimeBreakpointsMap.has(2)).toBe(false);
+		expect(session.runtimeBreakpointsMap.has(1)).toBe(true);
+		expect(session.runtimePostponedBreakpointsMap.has(2)).toBe(false);
+		expect(session.runtimePostponedBreakpointsMap.has(1)).toBe(true);
+		expect(session.currentStoppedThreadId).toBe(1);
+	});
+
+	test('child runtime close emits thread exit and clears thread state', async () => {
+		session.request = jest.fn().mockResolvedValue(['cmd', 'ok', 'DB<1>']);
+		session.frameThreadMap.set(501, 2);
+		session.variableThreadMap.set(502, 2);
+		const { StreamCatcher } = require('../streamCatcher');
+		jest.spyOn(StreamCatcher.prototype, 'launch').mockResolvedValue(undefined);
+		jest.spyOn(session, 'syncRuntimeBreakpoints').mockResolvedValue(undefined);
+
+		const childSocket = createThreadAwareMockSocket();
+		await session.registerChildRuntime(childSocket as any);
+		childSocket.emit('close');
+
+		expect(session.runtimes.has(2)).toBe(false);
+		expect(session.runtimeBreakpointsMap.has(2)).toBe(false);
+		expect(session.runtimePostponedBreakpointsMap.has(2)).toBe(false);
+		expect(session.frameThreadMap.has(501)).toBe(false);
+		expect(session.variableThreadMap.has(502)).toBe(false);
+
+		const sentEvents = (session.sendEvent as jest.Mock).mock.calls.map((call) => call[0]);
+		const threadEvents = sentEvents.filter((event) => event.event === 'thread');
+		expect(threadEvents.some((event) => event.body.reason === 'started' && event.body.threadId === 2)).toBe(true);
+		expect(threadEvents.some((event) => event.body.reason === 'exited' && event.body.threadId === 2)).toBe(true);
+	});
+
+	test('late child attach synchronizes latest desired breakpoints and function breakpoints', async () => {
+		session.desiredBreakpointsMap.set('C:\\repo\\test.pl', [{ id: 10, line: 25, condition: '$x > 1' }]);
+		session.funcBps = [{ name: 'My::func', condition: '1' }];
+		session.changeFileContext = jest.fn().mockResolvedValue('test.pl');
+		session.request = jest.fn().mockResolvedValue(['cmd', 'ok', 'DB<1>']);
+		const { StreamCatcher } = require('../streamCatcher');
+		jest.spyOn(StreamCatcher.prototype, 'launch').mockResolvedValue(undefined);
+
+		const childSocket = createThreadAwareMockSocket();
+		await session.registerChildRuntime(childSocket as any);
+
+		expect(session.changeFileContext).toHaveBeenCalledWith('C:\\repo\\test.pl', 2);
+		expect(session.request).toHaveBeenCalledWith('b 25 $x > 1', 2);
+		expect(session.request).toHaveBeenCalledWith('b My::func 1', 2);
+		expect(session.runtimeBreakpointsMap.get(2).get('C:\\repo\\test.pl')).toEqual([{ id: 10, line: 25, condition: '$x > 1' }]);
+	});
+
+	test('late child attach initializes postponed overlay from desired state, not primary runtime overlay drift', async () => {
+		session.desiredPostponedBreakpointsMap.set('C:\\repo\\late.pl', [{ id: 1, line: 11, condition: 'desired' }]);
+		session.runtimePostponedBreakpointsMap.set(1, new Map([
+			['C:\\repo\\late.pl', [{ id: 2, line: 22, condition: 'primary-only' }]]
+		]));
+		session.syncRuntimeBreakpoints = jest.fn().mockResolvedValue(undefined);
+		const { StreamCatcher } = require('../streamCatcher');
+		jest.spyOn(StreamCatcher.prototype, 'launch').mockResolvedValue(undefined);
+
+		const childSocket = createThreadAwareMockSocket();
+		await session.registerChildRuntime(childSocket as any);
+
+		expect(session.runtimePostponedBreakpointsMap.get(2).get('C:\\repo\\late.pl')).toEqual([{ id: 1, line: 11, condition: 'desired' }]);
+		expect(session.runtimePostponedBreakpointsMap.get(2).get('C:\\repo\\late.pl')).not.toEqual([{ id: 2, line: 22, condition: 'primary-only' }]);
+	});
+
+	test('late child attach after repeated desired breakpoint updates syncs only latest revision', async () => {
+		session.desiredBreakpointsMap.set('C:\\repo\\test.pl', [{ id: 1, line: 10, condition: 'old' }]);
+		session.desiredBreakpointsMap.set('C:\\repo\\test.pl', [{ id: 2, line: 40, condition: 'latest' }]);
+		session.changeFileContext = jest.fn().mockResolvedValue('test.pl');
+		session.request = jest.fn().mockResolvedValue(['cmd', 'ok', 'DB<1>']);
+		const { StreamCatcher } = require('../streamCatcher');
+		jest.spyOn(StreamCatcher.prototype, 'launch').mockResolvedValue(undefined);
+
+		const childSocket = createThreadAwareMockSocket();
+		await session.registerChildRuntime(childSocket as any);
+
+		expect(session.request).toHaveBeenCalledWith('b 40 latest', 2);
+		expect(session.request).not.toHaveBeenCalledWith('b 10 old', 2);
+		expect(session.runtimeBreakpointsMap.get(2).get('C:\\repo\\test.pl')).toEqual([{ id: 2, line: 40, condition: 'latest' }]);
+	});
+});

--- a/src/tests/debugAdapter.test.ts
+++ b/src/tests/debugAdapter.test.ts
@@ -18,16 +18,22 @@ describe('Perl Debug Adapter', () => {
 
 	beforeEach(async () => {
 		await dc.start();
-		// launch test script
-		await dc.launch({
-			type: 'perl',
-			request: 'launch',
-			name: 'Perl Debug',
-			program: PERL_SCRIPT,
-			stopOnEntry: true,
-			cwd: CWD,
-			sortKeys: true,
-		});
+		// launch test script; also await the StoppedEvent('entry') so that the
+		// event is fully drained from dc before the test body registers any
+		// new waitForEvent('stopped') listeners.
+		await Promise.all([
+			dc.waitForEvent('stopped'),
+			dc.launch({
+				type: 'perl',
+				request: 'launch',
+				name: 'Perl Debug',
+				program: PERL_SCRIPT,
+				stopOnEntry: true,
+				cwd: CWD,
+				transport: 'stdio',
+				sortKeys: true,
+			}),
+		]);
 	});
 
 	afterEach(async () => {
@@ -82,10 +88,199 @@ describe('Perl Debug Adapter', () => {
 		test('stop on postponed breakpoint', async () => {
 			const setBps = await dc.setBreakpointsRequest({ source: { path: INCLUDED_PERL_SCRIPT }, breakpoints: [{ line: 5 }] });
 			expect(setBps.success).toBe(true);
+			// Register the listener BEFORE continuing. Because beforeEach already
+			// drained the entry stop, this will only catch the NEXT stopped event
+			// (the forced stop that fires when dbconfig.pl is loaded and the
+			// breakpoint at line 5 is applied).
+			const stoppedPromise = dc.waitForEvent('stopped');
 			const cont = await dc.continueRequest({ threadId: 1 });
 			expect(cont.success).toBe(true);
+			await stoppedPromise;
+			const trace = await dc.stackTraceRequest({ threadId: 1 });
+			expect(trace.success).toBe(true);
+			expect(trace.body.stackFrames[0].source!.path).toBe(INCLUDED_PERL_SCRIPT);
+			expect(trace.body.stackFrames[0].line).toBe(5);
+		});
+
+		test('stop on entry is not broken by pre-launch breakpoints for other files', async () => {
+			// Regression: applying pre-launch breakpoints for non-main-script files
+			// triggered a perl5db regex crash on Windows paths, killing the process
+			// before StoppedEvent('entry') was ever sent.
+			await dc.terminateRequest();
+			await dc.stop();
+			await dc.start();
+
+			await dc.initializeRequest();
+
+			// IDE sends breakpoints for multiple files during the config phase
+			await dc.setBreakpointsRequest({ source: { path: PERL_SCRIPT }, breakpoints: [{ line: 10 }] });
+			await dc.setBreakpointsRequest({ source: { path: INCLUDED_PERL_SCRIPT }, breakpoints: [{ line: 5 }] });
+
+			const stoppedPromise = dc.waitForEvent('stopped');
+
+			await dc.launchRequest({
+				type: 'perl',
+				request: 'launch',
+				name: 'Perl Debug',
+				program: PERL_SCRIPT,
+				stopOnEntry: true,
+				cwd: CWD,
+				transport: 'stdio',
+				sortKeys: true,
+			} as any);
+
+			const stoppedEvent = await stoppedPromise;
+			expect(stoppedEvent.body.reason).toBe('entry');
+
+			const trace = await dc.stackTraceRequest({ threadId: 1 });
+			expect(trace.success).toBe(true);
+			expect(trace.body.stackFrames[0].source!.path).toBe(PERL_SCRIPT);
+			expect(trace.body.stackFrames[0].line).toBe(7);
+		});
+
+		test('breakpoints set before session launch are hit', async () => {
+			// Simulate the IDE behaviour: breakpoints already selected before F5 is pressed.
+			// The IDE sends setBreakpoints during the configuration sequence (after InitializedEvent
+			// but before launch), so the adapter must not discard them when launchRequest runs.
+			await dc.terminateRequest();
+			await dc.stop();
+			await dc.start();
+
+			// Trigger InitializedEvent by sending the initialize request
+			await dc.initializeRequest();
+
+			// Set a breakpoint on line 10 BEFORE the launch request is sent
+			await dc.setBreakpointsRequest({ source: { path: PERL_SCRIPT }, breakpoints: [{ line: 10 }] });
+
+			// Register the stopped listener before launching so the event is not missed
+			const stoppedPromise = dc.waitForEvent('stopped');
+
+			// Launch without stopOnEntry ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“ the only reason to stop should be the pre-set breakpoint
+			await dc.launchRequest({
+				type: 'perl',
+				request: 'launch',
+				name: 'Perl Debug',
+				program: PERL_SCRIPT,
+				stopOnEntry: false,
+				cwd: CWD,
+				transport: 'stdio',
+				sortKeys: true,
+			} as any);
+
+			await stoppedPromise;
+
+			const trace = await dc.stackTraceRequest({ threadId: 1 });
+			expect(trace.success).toBe(true);
+			expect(trace.body.stackFrames[0].source!.path).toBe(PERL_SCRIPT);
+			expect(trace.body.stackFrames[0].line).toBe(10);
+		});
+
+		test('pre-launch breakpoints in multiple files still stop on entry first', async () => {
+			await dc.terminateRequest();
+			await dc.stop();
+			await dc.start();
+
+			await dc.initializeRequest();
+
+			// Simulate VS Code sending all workspace breakpoints before launch.
+			const mainSet = await dc.setBreakpointsRequest({ source: { path: PERL_SCRIPT }, breakpoints: [{ line: 10 }] });
+			expect(mainSet.success).toBe(true);
+			const includedSet = await dc.setBreakpointsRequest({ source: { path: INCLUDED_PERL_SCRIPT }, breakpoints: [{ line: 5 }] });
+			expect(includedSet.success).toBe(true);
+			const printfSet = await dc.setBreakpointsRequest({ source: { path: Path.join(CWD, 'printf.pl') }, breakpoints: [{ line: 11 }] });
+			expect(printfSet.success).toBe(true);
+
+			const stoppedPromise = dc.waitForEvent('stopped');
+
+			await dc.launchRequest({
+				type: 'perl',
+				request: 'launch',
+				name: 'Perl Debug',
+				program: PERL_SCRIPT,
+				stopOnEntry: true,
+				cwd: CWD,
+				transport: 'stdio',
+				sortKeys: true,
+			} as any);
+
+			const stoppedEvent = await stoppedPromise;
+			expect(stoppedEvent.body.reason).toBe('entry');
+
+			const trace = await dc.stackTraceRequest({ threadId: 1 });
+			expect(trace.success).toBe(true);
+			expect(trace.body.stackFrames[0].source!.path).toBe(PERL_SCRIPT);
+			expect(trace.body.stackFrames[0].line).toBe(7);
+		});
+
+		test('non-main pre-launch breakpoint remains postponed until file is loaded', async () => {
+			await dc.terminateRequest();
+			await dc.stop();
+			await dc.start();
+
+			await dc.initializeRequest();
+
+			const includedSet = await dc.setBreakpointsRequest({ source: { path: INCLUDED_PERL_SCRIPT }, breakpoints: [{ line: 5 }] });
+			expect(includedSet.success).toBe(true);
+
+			const entryStopped = dc.waitForEvent('stopped');
+			await dc.launchRequest({
+				type: 'perl',
+				request: 'launch',
+				name: 'Perl Debug',
+				program: PERL_SCRIPT,
+				stopOnEntry: true,
+				cwd: CWD,
+				transport: 'stdio',
+				sortKeys: true,
+			} as any);
+			await entryStopped;
+
+			// At entry we are still in test.pl, so dbconfig.pl breakpoints must still be postponed.
 			let trace = await dc.stackTraceRequest({ threadId: 1 });
+			expect(trace.success).toBe(true);
+			expect(trace.body.stackFrames[0].source!.path).toBe(PERL_SCRIPT);
+			expect(trace.body.stackFrames[0].line).toBe(7);
+
+			const loadedStop = dc.waitForEvent('stopped');
+			const cont = await dc.continueRequest({ threadId: 1 });
+			expect(cont.success).toBe(true);
+			await loadedStop;
+
 			trace = await dc.stackTraceRequest({ threadId: 1 });
+			expect(trace.success).toBe(true);
+			expect(trace.body.stackFrames[0].source!.path).toBe(INCLUDED_PERL_SCRIPT);
+			expect(trace.body.stackFrames[0].line).toBe(5);
+		});
+
+		test('non-main pre-launch breakpoint is eventually hit after file load', async () => {
+			await dc.terminateRequest();
+			await dc.stop();
+			await dc.start();
+
+			await dc.initializeRequest();
+
+			const includedSet = await dc.setBreakpointsRequest({ source: { path: INCLUDED_PERL_SCRIPT }, breakpoints: [{ line: 5 }] });
+			expect(includedSet.success).toBe(true);
+
+			const entryStopped = dc.waitForEvent('stopped');
+			await dc.launchRequest({
+				type: 'perl',
+				request: 'launch',
+				name: 'Perl Debug',
+				program: PERL_SCRIPT,
+				stopOnEntry: true,
+				cwd: CWD,
+				transport: 'stdio',
+				sortKeys: true,
+			} as any);
+			await entryStopped;
+
+			const loadedStop = dc.waitForEvent('stopped');
+			const cont = await dc.continueRequest({ threadId: 1 });
+			expect(cont.success).toBe(true);
+			await loadedStop;
+
+			const trace = await dc.stackTraceRequest({ threadId: 1 });
 			expect(trace.success).toBe(true);
 			expect(trace.body.stackFrames[0].source!.path).toBe(INCLUDED_PERL_SCRIPT);
 			expect(trace.body.stackFrames[0].line).toBe(5);
@@ -127,6 +322,7 @@ describe('Perl Debug Adapter', () => {
 				program: BROKEN_PERL_SCRIPT,
 				stopOnEntry: true,
 				cwd: CWD,
+				transport: 'stdio',
 				sortKeys: true,
 			}).then(() => {
 				fail('launch request should not complete');
@@ -224,11 +420,23 @@ describe('PerlDebugSession fork handling', () => {
 	});
 
 	test('terminates unsupported forked sessions to avoid corrupted state', () => {
+		session.activeTransport = 'stdio';
 		session.handleSessionOutput('Forked, but do not know how to create a new TTY', 'stderr');
 
 		expect(session._session.kill).toHaveBeenCalledTimes(1);
 		expect(events.some((event) => event.event === 'terminated')).toBe(true);
 		expect(events.some((event) => event.event === 'output' && event.body.category === 'important' && event.body.output.includes('not supported by this adapter'))).toBe(true);
+	});
+
+	test('does not terminate on unsupported-fork warning when socket transport is active', () => {
+		session.activeTransport = 'socket';
+		session.handleSessionOutput('Forked, but do not know how to create a new TTY', 'stderr');
+
+		expect(session._session.kill).not.toHaveBeenCalled();
+		expect(events.some((event) => event.event === 'terminated')).toBe(false);
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe('output');
+		expect(events[0].body.category).toBe('stderr');
 	});
 
 	test('forwards normal process output without terminating the session', () => {
@@ -395,7 +603,50 @@ describe('PerlDebugSession launch transport setup', () => {
 		} as any;
 	}
 
-	test('uses stdio transport by default', async () => {
+	test('uses socket transport by default', async () => {
+		jest.resetModules();
+
+		const child = createMockChildProcess();
+		const socket = { destroyed: false, destroy: jest.fn() };
+		let server: any;
+		const spawnMock = jest.fn(() => child);
+		const createServerMock = jest.fn((onConnection: Function) => {
+			server = createMockSocketServer(onConnection, socket);
+			return server;
+		});
+
+		jest.doMock('child_process', () => ({
+			...jest.requireActual('child_process'),
+			spawn: spawnMock
+		}));
+		jest.doMock('net', () => ({
+			...jest.requireActual('net'),
+			createServer: createServerMock
+		}));
+
+		const { PerlDebugSession } = require('../perlDebug');
+		const session = new PerlDebugSession();
+		(session as any).streamCatcher = { launch: jest.fn().mockResolvedValue([]), getBuffer: jest.fn(() => []), request: jest.fn() };
+		jest.spyOn(session as any, 'request').mockResolvedValue(['ok']);
+		session.sendEvent = jest.fn();
+		(session as any).logSendResponse = jest.fn();
+
+		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs());
+
+		expect(createServerMock).toHaveBeenCalledTimes(1);
+		expect(spawnMock).toHaveBeenCalledWith(
+			'perl',
+			expect.any(Array),
+			expect.objectContaining({
+				env: expect.objectContaining({
+					PERLDB_OPTS: 'ReadLine=0 RemotePort=127.0.0.1:43123'
+				})
+			})
+		);
+		expect((session as any).streamCatcher.launch).toHaveBeenCalledWith(socket, socket);
+	});
+
+	test('uses stdio transport when requested', async () => {
 		jest.resetModules();
 
 		const child = createMockChildProcess();
@@ -418,7 +669,7 @@ describe('PerlDebugSession launch transport setup', () => {
 		session.sendEvent = jest.fn();
 		(session as any).logSendResponse = jest.fn();
 
-		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs());
+		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs({ transport: 'stdio' }));
 
 		expect(createServerMock).not.toHaveBeenCalled();
 		expect(spawnMock).toHaveBeenCalledWith(
@@ -553,7 +804,7 @@ describe('PerlDebugSession launch transport setup', () => {
 		session.sendEvent = jest.fn();
 		(session as any).logSendResponse = jest.fn();
 
-		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs({ stopOnEntry: true }));
+		await (session as any).launchRequest(createLaunchResponse(), createLaunchArgs({ stopOnEntry: true, transport: 'stdio' }));
 
 		const events = (session.sendEvent as jest.Mock).mock.calls.map((call) => call[0]);
 		const stoppedIndex = events.findIndex((event) => event.event === 'stopped' && event.body.reason === 'entry');
@@ -801,6 +1052,28 @@ describe('PerlDebugSession thread-aware routing', () => {
 
 		expect(session.runtimePostponedBreakpointsMap.get(1).has('C:\\repo\\late.pl')).toBe(true);
 		expect(session.runtimePostponedBreakpointsMap.get(2).has('C:\\repo\\late.pl')).toBe(true);
+	});
+
+	test('changeFileContext treats perl5db regex errors as failure', async () => {
+		session.request = jest.fn()
+			// basename candidate => not loaded
+			.mockResolvedValueOnce(['f fork_socket_manual.pl', "No file matching 'fork_socket_manual.pl' is loaded.", 'DB<1>'])
+			// absolute candidate => perl5db regex error on Windows-style backslashes
+			.mockResolvedValueOnce([
+				'f C:\\repo\\fork_socket_manual.pl',
+				'\\C no longer supported in regex; marked by <-- HERE in m/^_<.*C:\\ <-- HERE repo\\fork_socket_manual.pl/ at C:/berrybrew/instance/5.38.0_64/perl/lib/perl5db.pl line 1899.',
+				'DB<1>'
+			])
+			// forward-slash absolute candidate => also not loaded
+			.mockResolvedValueOnce(['f C:/repo/fork_socket_manual.pl', "No file matching 'C:/repo/fork_socket_manual.pl' is loaded.", 'DB<1>']);
+
+		const changed = await session.changeFileContext('C:\\repo\\fork_socket_manual.pl', 1);
+
+		expect(changed).toBeUndefined();
+		expect(session.request).toHaveBeenCalledTimes(3);
+		expect(session.request).toHaveBeenNthCalledWith(1, 'f fork_socket_manual.pl', 1);
+		expect(session.request).toHaveBeenNthCalledWith(2, 'f C:\\repo\\fork_socket_manual.pl', 1);
+		expect(session.request).toHaveBeenNthCalledWith(3, 'f C:/repo/fork_socket_manual.pl', 1);
 	});
 
 	test('runtime postponed overlays are cloned from desired state', () => {

--- a/src/tests/debugAdapter.test.ts
+++ b/src/tests/debugAdapter.test.ts
@@ -1,6 +1,5 @@
 import * as Path from 'path';
 import { DebugClient } from '@vscode/debugadapter-testsupport';
-import * as fs from 'fs';
 
 jest.setTimeout(10000);
 
@@ -347,7 +346,30 @@ describe('Perl Debug Adapter', () => {
 			expect(evaluate.success).toBe(true);
 			const variable = await dc.variablesRequest({ variablesReference: evaluate.body.variablesReference });
 			expect(variable.success).toBe(true);
-			expect(JSON.parse(fs.readFileSync(Path.join(CWD, 'variables', 'list.json')).toString())).toEqual(variable.body);
+			expect(variable.body.variables.map((entry) => entry.name)).toEqual(['0', '1', '2', '3']);
+			expect(variable.body.variables.map((entry) => entry.value)).toEqual(['1', '2', '3', '"test"']);
+			expect(variable.body.variables.every((entry) => entry.type === 'SCALAR')).toBe(true);
+		});
+
+		test('setVariable updates array entry end-to-end', async () => {
+			expect(await goToLine(21)).toBe(true);
+			const evaluate = await dc.evaluateRequest({ expression: '@list' });
+			expect(evaluate.success).toBe(true);
+
+			const before = await dc.variablesRequest({ variablesReference: evaluate.body.variablesReference });
+			expect(before.success).toBe(true);
+
+			const updated = await dc.setVariableRequest({
+				variablesReference: evaluate.body.variablesReference,
+				name: '1',
+				value: '42'
+			} as any);
+			expect(updated.success).toBe(true);
+			expect(updated.body.value).toBe('42');
+
+			const variable = await dc.variablesRequest({ variablesReference: evaluate.body.variablesReference });
+			expect(variable.success).toBe(true);
+			expect(variable.body.variables.map((entry) => entry.value)).toEqual(['1', '42', '3', '"test"']);
 		});
 
 		test('hash', async () => {
@@ -361,7 +383,7 @@ describe('Perl Debug Adapter', () => {
 			const barFoo = variable.body.variables.find((entry) => entry.name === 'Bar Foo');
 			expect(barFoo).toBeDefined();
 			expect(barFoo?.type).toBe('HASH');
-			expect(barFoo?.namedVariables).toBe(3);
+			expect(barFoo?.variablesReference).toBeGreaterThan(0);
 
 			const barFooChildren = await dc.variablesRequest({ variablesReference: barFoo!.variablesReference });
 			expect(barFooChildren.success).toBe(true);
@@ -370,7 +392,34 @@ describe('Perl Debug Adapter', () => {
 			const art = barFooChildren.body.variables.find((entry) => entry.name === 'Art');
 			expect(art).toBeDefined();
 			expect(art?.type).toBe('HASH');
-			expect(art?.namedVariables).toBe(1);
+			expect(art?.variablesReference).toBeGreaterThan(0);
+		});
+
+		test('setVariable updates nested hash entry end-to-end', async () => {
+			expect(await goToLine(21)).toBe(true);
+			const evaluate = await dc.evaluateRequest({ expression: '%grades' });
+			expect(evaluate.success).toBe(true);
+
+			const variable = await dc.variablesRequest({ variablesReference: evaluate.body.variablesReference });
+			expect(variable.success).toBe(true);
+			const barFoo = variable.body.variables.find((entry) => entry.name === 'Bar Foo');
+			expect(barFoo).toBeDefined();
+
+			const before = await dc.variablesRequest({ variablesReference: barFoo!.variablesReference });
+			expect(before.success).toBe(true);
+
+			const updated = await dc.setVariableRequest({
+				variablesReference: barFoo!.variablesReference,
+				name: '1',
+				value: '456'
+			} as any);
+			expect(updated.success).toBe(true);
+			expect(updated.body.value).toBe('456');
+
+			const barFooChildren = await dc.variablesRequest({ variablesReference: barFoo!.variablesReference });
+			expect(barFooChildren.success).toBe(true);
+			const scalarEntry = barFooChildren.body.variables.find((entry) => entry.name === '1');
+			expect(scalarEntry?.value).toBe('456');
 		});
 
 		test('nested object', async () => {
@@ -912,7 +961,7 @@ describe('PerlDebugSession thread-aware routing', () => {
 		const varsResponse: any = { seq: 3, type: 'response', request_seq: 3, command: 'variables', success: true };
 		await session.variablesRequest(varsResponse, { variablesReference: myScopeRef } as any);
 
-		expect(session.request).toHaveBeenCalledWith('print STDERR join ("|", sort(keys( % { PadWalker::peek_my(2); })))', 2);
+		expect(session.request).toHaveBeenCalledWith('print STDERR join ("|", sort(keys( % { PadWalker::peek_my(2); }))) . "\\n"', 2);
 	});
 
 	test('routes evaluate request to frame thread', async () => {
@@ -937,6 +986,79 @@ describe('PerlDebugSession thread-aware routing', () => {
 
 		expect(session.getExpression).toHaveBeenCalledWith(123, 'x', 2);
 		expect((session.request as jest.Mock).mock.calls[0][1]).toBe(2);
+	});
+
+	test('setVariable updates nested array entries using loaded evaluateName', async () => {
+		const response: any = { seq: 6, type: 'response', request_seq: 6, command: 'setVariable', success: true };
+		session.variableThreadMap.set(123, 2);
+		session.childVarsMap.set(200123, [{
+			name: '100',
+			value: '100',
+			variablesReference: 0,
+			evaluateName: '$large_array[100]'
+		}]);
+		session.getExpression = jest.fn().mockReturnValue('$wrong[100]');
+		session.request = jest.fn()
+			.mockResolvedValueOnce(['cmd', 'DB<1>'])
+			.mockResolvedValueOnce(['cmd', '42', 'DB<1>']);
+
+		await session.setVariableRequest(response, {
+			variablesReference: 123,
+			name: '100',
+			value: '42'
+		} as any);
+
+		expect(session.getExpression).not.toHaveBeenCalled();
+		expect((session.request as jest.Mock).mock.calls[0][0]).toContain('$large_array[100] = 42');
+		expect(response.body.value).toBe('42');
+	});
+
+	test('setVariable updates nested hash entries using loaded evaluateName', async () => {
+		const response: any = { seq: 7, type: 'response', request_seq: 7, command: 'setVariable', success: true };
+		session.variableThreadMap.set(124, 2);
+		session.childVarsMap.set(200124, [{
+			name: '10',
+			value: '10',
+			variablesReference: 0,
+			evaluateName: "$large_hash{'10'}"
+		}]);
+		session.getExpression = jest.fn().mockReturnValue("$wrong{'10'}");
+		session.request = jest.fn()
+			.mockResolvedValueOnce(['cmd', 'DB<1>'])
+			.mockResolvedValueOnce(['cmd', '99', 'DB<1>']);
+
+		await session.setVariableRequest(response, {
+			variablesReference: 124,
+			name: '10',
+			value: '99'
+		} as any);
+
+		expect(session.getExpression).not.toHaveBeenCalled();
+		expect((session.request as jest.Mock).mock.calls[0][0]).toContain("$large_hash{'10'} = 99");
+		expect(response.body.value).toBe('99');
+	});
+
+	test('setVariable reloads children when evaluateName cache is missing', async () => {
+		const response: any = { seq: 8, type: 'response', request_seq: 8, command: 'setVariable', success: true };
+		session.variableThreadMap.set(125, 2);
+		session.getExpression = jest.fn().mockReturnValue('4');
+		session.loadContainerChildren = jest.fn().mockResolvedValue([
+			{ name: '4', value: '4', variablesReference: 0, evaluateName: "$large_hash{'4'}" }
+		]);
+		session.request = jest.fn()
+			.mockResolvedValueOnce(['cmd', 'DB<1>'])
+			.mockResolvedValueOnce(['cmd', '312312', 'DB<1>']);
+
+		await session.setVariableRequest(response, {
+			variablesReference: 125,
+			name: '4',
+			value: '312312'
+		} as any);
+
+		expect(session.loadContainerChildren).toHaveBeenCalledWith(125, 2);
+		expect((session.request as jest.Mock).mock.calls[0][0]).toContain("$large_hash{'4'} = 312312");
+		expect(response.body.value).toBe('312312');
+		expect(session.getExpression).not.toHaveBeenCalled();
 	});
 
 	test('rejects duplicate continue while same thread execution command is in-flight', () => {
@@ -1093,6 +1215,225 @@ describe('PerlDebugSession thread-aware routing', () => {
 
 		expect(session.runtimePostponedBreakpointsMap.get(2).get('C:\\repo\\late.pl')).toEqual([{ id: 2, line: 22, condition: '2' }]);
 		expect(session.desiredPostponedBreakpointsMap.get('C:\\repo\\late.pl')).toEqual([{ id: 1, line: 11, condition: '1' }]);
+	});
+
+	test('parseDumper does not eagerly populate nested child containers', () => {
+		const parentRef = 900;
+		session.parseDumper([
+			"'outer' => {",
+			"  'inner' => 1,",
+			'},',
+			'}'
+		], 1, parentRef, '$root');
+
+		const parentChildren = session.childVarsMap.get(100900);
+		expect(parentChildren).toBeDefined();
+		const outer = parentChildren.find((entry: any) => entry.name === 'outer');
+		expect(outer).toBeDefined();
+		expect(outer.variablesReference).toBeGreaterThan(0);
+		expect(session.childVarsMap.has(100000 + outer.variablesReference)).toBe(false);
+	});
+
+	test('parseDumper splits large arrays into chunk nodes using maxArrayElements', () => {
+		session.maxArrayElements = 2;
+		const parentRef = 901;
+		session.parseDumper([
+			'1,',
+			'2,',
+			'3,',
+			'4,',
+			'5,',
+			']'
+		], 1, parentRef, '@list');
+
+		const parentChildren = session.childVarsMap.get(100901);
+		expect(parentChildren.length).toBe(3);
+		expect(parentChildren.map((entry: any) => entry.name)).toEqual(['[0..1]', '[2..3]', '[4..4]']);
+
+		const firstChunkRef = parentChildren[0].variablesReference;
+		const firstChunkChildren = session.childVarsMap.get(100000 + firstChunkRef);
+		expect(firstChunkChildren.length).toBe(2);
+		expect(firstChunkChildren.map((entry: any) => entry.name)).toEqual(['0', '1']);
+	});
+
+	test('parseVars stores lazy container metadata instead of eagerly populating root array children', async () => {
+		session.parseVars = Object.getPrototypeOf(session).parseVars.bind(session);
+		session.getContainerSize = jest.fn().mockResolvedValue(250);
+		session.request = jest.fn().mockResolvedValue([
+			'cmd',
+			'250',
+			'DB<1>'
+		]);
+
+		const parsed = await session.parseVars(['@large_array'], 1);
+
+		expect(parsed).toHaveLength(1);
+		expect(parsed[0].variablesReference).toBeGreaterThan(0);
+		expect(session.getContainerSize).toHaveBeenCalledWith('@large_array', 'ARRAY', 1);
+		expect(session.request).not.toHaveBeenCalled();
+		expect(session.childVarsMap.has(100000 + parsed[0].variablesReference)).toBe(false);
+		expect(session.containerMetaMap.get(100000 + parsed[0].variablesReference)).toEqual({
+			expression: '@large_array',
+			type: 'ARRAY',
+			total: 250
+		});
+	});
+
+	test('parseVars stops after max variable dump retries when no dump header appears', async () => {
+		session.parseVars = Object.getPrototypeOf(session).parseVars.bind(session);
+		session.request = jest.fn().mockImplementation(async (command: string) => {
+			if (command.startsWith('print {$DB::OUT} Data::Dumper->new')) {
+				return ['cmd', 'garbage output', 'DB<1>'];
+			}
+			if (command === 'c') {
+				return ['c', 'still not a dump', 'DB<1>'];
+			}
+			return ['cmd', 'DB<1>'];
+		});
+
+		const parsed = await session.parseVars(['$x'], 1);
+
+		expect(parsed).toHaveLength(1);
+		expect(parsed[0].type).toBe('UNDEF');
+		const continueCalls = (session.request as jest.Mock).mock.calls.filter((call: any[]) => call[0] === 'c').length;
+		expect(continueCalls).toBe(25);
+	});
+
+	test('root array expansion returns direct chunk nodes without an extra outer level', async () => {
+		session.parseVars = Object.getPrototypeOf(session).parseVars.bind(session);
+		session.maxArrayElements = 100;
+		session.getContainerSize = jest.fn().mockResolvedValue(250);
+		session.request = jest.fn().mockResolvedValue([
+			'cmd',
+			'250',
+			'DB<1>'
+		]);
+
+		const parsed = await session.parseVars(['@large_array'], 1);
+		const vars = await session.loadContainerChildren(parsed[0].variablesReference, 1);
+
+		expect(parsed[0].indexedVariables).toBeUndefined();
+		expect(vars.map((entry: any) => entry.name)).toEqual(['[0..99]', '[100..199]', '[200..249]']);
+		expect(session.request).not.toHaveBeenCalled();
+	});
+
+	test('large root arrays keep chunk variable references positive for deep expansion', async () => {
+		session.parseVars = Object.getPrototypeOf(session).parseVars.bind(session);
+		session.maxArrayElements = 100;
+		session.getContainerSize = jest.fn().mockResolvedValue(1000000);
+
+		const parsed = await session.parseVars(['@large_array'], 1);
+		const vars = await session.loadContainerChildren(parsed[0].variablesReference, 1);
+
+		expect(vars).toHaveLength(10000);
+		expect(vars[0].variablesReference).toBeGreaterThan(1000);
+		expect(vars[vars.length - 1].variablesReference).toBeGreaterThan(1000);
+	});
+
+	test('small root arrays still expose indexedVariables for direct expansion', async () => {
+		session.parseVars = Object.getPrototypeOf(session).parseVars.bind(session);
+		session.maxArrayElements = 100;
+		session.getContainerSize = jest.fn().mockResolvedValue(4);
+
+		const parsed = await session.parseVars(['@list'], 1);
+
+		expect(parsed).toHaveLength(1);
+		expect(parsed[0].indexedVariables).toBe(4);
+	});
+
+	test('loadContainerChildren returns chunk nodes with sane evaluate names', async () => {
+		session.maxArrayElements = 100;
+		session.containerMetaMap.set(100901, { expression: '@large_array', type: 'ARRAY', total: 250 });
+
+		const vars = await session.loadContainerChildren(901, 1);
+
+		expect(vars.map((entry: any) => entry.name)).toEqual(['[0..99]', '[100..199]', '[200..249]']);
+		expect(vars.every((entry: any) => entry.evaluateName === '$large_array')).toBe(true);
+		expect(vars.every((entry: any) => !entry.evaluateName.includes('[[‘') && !entry.evaluateName.includes('[['))).toBe(true);
+	});
+
+	test('variablesRequest treats high adapter refs as nested variables instead of scopes', async () => {
+		session.childVarsMap.set(110050, [{ name: '100', value: '100', variablesReference: 0 }]);
+		session.variableThreadMap.set(10050, 1);
+		const response: any = { seq: 1, type: 'response', request_seq: 1, command: 'variables', success: true };
+
+		await session.variablesRequest(response, { variablesReference: 10050 } as any);
+
+		expect(response.body.variables).toHaveLength(1);
+		expect(response.body.variables[0]).toMatchObject({ name: '100', value: '100', variablesReference: 0, evaluateName: '$x' });
+		expect(session.request).not.toHaveBeenCalled();
+	});
+
+	test('expanding one array chunk loads only that chunk range', async () => {
+		session.chunkMetaMap.set(100998, {
+			parentExpression: '@large_array',
+			type: 'ARRAY',
+			start: 100,
+			end: 199
+		});
+		session.request = jest.fn().mockResolvedValue([
+			'cmd',
+			'$VAR1 = [',
+			'  100,',
+			'  101,',
+			'  102,',
+			'];',
+			'DB<1>'
+		]);
+
+		const vars = await session.loadContainerChildren(998, 1);
+
+		expect(session.request).toHaveBeenCalledTimes(1);
+		expect((session.request as jest.Mock).mock.calls[0][0]).toContain('[100..199]');
+		expect(vars.map((entry: any) => entry.name)).toEqual(['100', '101', '102']);
+		expect(vars.map((entry: any) => entry.evaluateName)).toEqual([
+			'$large_array[100]',
+			'$large_array[101]',
+			'$large_array[102]'
+		]);
+	});
+
+	test('loadContainerChildren returns hash chunk nodes using maxHashElements', async () => {
+		session.maxHashElements = 2;
+		session.containerMetaMap.set(100902, { expression: '%large_hash', type: 'HASH', total: 5 });
+
+		const vars = await session.loadContainerChildren(902, 1);
+
+		expect(vars.map((entry: any) => entry.name)).toEqual(['[keys 0..1]', '[keys 2..3]', '[keys 4..4]']);
+		expect(vars.every((entry: any) => entry.evaluateName === '$large_hash')).toBe(true);
+	});
+
+	test('loadChunkChildren requests numeric-aware ordering for hash chunk keys', async () => {
+		session.chunkMetaMap.set(100903, {
+			parentExpression: '%large_hash',
+			type: 'HASH',
+			start: 0,
+			end: 4
+		});
+		session.request = jest.fn().mockResolvedValue([
+			'cmd',
+			'0\t1\t2\t10\t11',
+			'DB<1>'
+		]);
+		session.parseVars = jest.fn().mockImplementation(async ([expression]: string[]) => [{
+			name: expression,
+			value: expression,
+			variablesReference: 0,
+			evaluateName: expression
+		}]);
+
+		const vars = await session.loadContainerChildren(903, 1);
+
+		expect((session.request as jest.Mock).mock.calls[0][0]).toContain('my $all_numeric = 1');
+		expect((session.request as jest.Mock).mock.calls[0][0]).toContain('$a <=> $b');
+		expect(vars.map((entry: any) => entry.name)).toEqual(['0', '1', '2', '10', '11']);
+		expect(vars.map((entry: any) => entry.evaluateName)).toEqual([
+			"$large_hash{'0'}",
+			"$large_hash{'1'}",
+			"$large_hash{'2'}",
+			"$large_hash{'10'}",
+			"$large_hash{'11'}"
+		]);
 	});
 
 	test('clearThreadScopedState removes per-thread frames variables and runtime overlays', () => {

--- a/src/tests/debugAdapter.test.ts
+++ b/src/tests/debugAdapter.test.ts
@@ -1496,6 +1496,20 @@ describe('PerlDebugSession thread-aware routing', () => {
 		expect(threadEvents.some((event) => event.body.reason === 'exited' && event.body.threadId === 2)).toBe(true);
 	});
 
+	test('terminateRequest uses process-tree termination helper', () => {
+		session.cleanupDebuggerTransport = jest.fn();
+		session.terminateSessionProcessTree = jest.fn();
+		session.logSendEvent = jest.fn();
+		session.logSendResponse = jest.fn();
+		const response: any = { seq: 90, type: 'response', request_seq: 90, command: 'terminate', success: true };
+
+		session.terminateRequest(response, {} as any);
+
+		expect(session.cleanupDebuggerTransport).toHaveBeenCalledTimes(1);
+		expect(session.terminateSessionProcessTree).toHaveBeenCalledTimes(1);
+		expect(session.logSendResponse).toHaveBeenCalledWith(response);
+	});
+
 	test('late child attach synchronizes latest desired breakpoints and function breakpoints', async () => {
 		session.desiredBreakpointsMap.set('C:\\repo\\test.pl', [{ id: 10, line: 25, condition: '$x > 1' }]);
 		session.funcBps = [{ name: 'My::func', condition: '1' }];

--- a/src/tests/debugAdapter.test.ts
+++ b/src/tests/debugAdapter.test.ts
@@ -1404,6 +1404,7 @@ describe('PerlDebugSession thread-aware routing', () => {
 	});
 
 	test('loadChunkChildren requests numeric-aware ordering for hash chunk keys', async () => {
+		session.sortKeys = true;
 		session.chunkMetaMap.set(100903, {
 			parentExpression: '%large_hash',
 			type: 'HASH',
@@ -1434,6 +1435,32 @@ describe('PerlDebugSession thread-aware routing', () => {
 			"$large_hash{'10'}",
 			"$large_hash{'11'}"
 		]);
+	});
+
+	test('loadChunkChildren does not sort hash keys when sortKeys is disabled', async () => {
+		session.sortKeys = false;
+		session.chunkMetaMap.set(100904, {
+			parentExpression: '%large_hash',
+			type: 'HASH',
+			start: 0,
+			end: 4
+		});
+		session.request = jest.fn().mockResolvedValue([
+			'cmd',
+			'10\t2\t1\t11\t0',
+			'DB<1>'
+		]);
+		session.parseVars = jest.fn().mockImplementation(async ([expression]: string[]) => [{
+			name: expression,
+			value: expression,
+			variablesReference: 0,
+			evaluateName: expression
+		}]);
+
+		const vars = await session.loadContainerChildren(904, 1);
+
+		expect((session.request as jest.Mock).mock.calls[0][0]).not.toContain('sort {');
+		expect(vars.map((entry: any) => entry.name)).toEqual(['10', '2', '1', '11', '0']);
 	});
 
 	test('clearThreadScopedState removes per-thread frames variables and runtime overlays', () => {

--- a/src/tests/debugAdapter.test.ts
+++ b/src/tests/debugAdapter.test.ts
@@ -160,7 +160,21 @@ describe('Perl Debug Adapter', () => {
 			expect(evaluate.success).toBe(true);
 			const variable = await dc.variablesRequest({ variablesReference: evaluate.body.variablesReference });
 			expect(variable.success).toBe(true);
-			expect(JSON.parse(fs.readFileSync(Path.join(CWD, 'variables', 'grades.json')).toString())).toEqual(variable.body);
+			expect(variable.body.variables.map((entry) => entry.name)).toEqual(['Bar Foo', 'Foo Bar']);
+
+			const barFoo = variable.body.variables.find((entry) => entry.name === 'Bar Foo');
+			expect(barFoo).toBeDefined();
+			expect(barFoo?.type).toBe('HASH');
+			expect(barFoo?.namedVariables).toBe(3);
+
+			const barFooChildren = await dc.variablesRequest({ variablesReference: barFoo!.variablesReference });
+			expect(barFooChildren.success).toBe(true);
+			expect(barFooChildren.body.variables.map((entry) => entry.name)).toEqual(['1', 'Art', 'Literature']);
+
+			const art = barFooChildren.body.variables.find((entry) => entry.name === 'Art');
+			expect(art).toBeDefined();
+			expect(art?.type).toBe('HASH');
+			expect(art?.namedVariables).toBe(1);
 		});
 
 		test('nested object', async () => {
@@ -169,7 +183,18 @@ describe('Perl Debug Adapter', () => {
 			expect(evaluate.success).toBe(true);
 			const variable = await dc.variablesRequest({ variablesReference: evaluate.body.variablesReference });
 			expect(variable.success).toBe(true);
-			expect(JSON.parse(fs.readFileSync(Path.join(CWD, 'variables', 'res.json')).toString())).toEqual(variable.body.variables[0]);
+			expect(variable.body.variables.length).toBeGreaterThan(0);
+
+			const content = variable.body.variables.find((entry) => entry.name === '_content');
+			expect(content).toBeDefined();
+			expect(content?.type).toBe('SCALAR');
+			expect(content?.presentationHint?.kind).toBe('data');
+			expect(content?.value.startsWith('"')).toBe(true);
+
+			const responseMetadata = variable.body.variables.map((entry) => entry.name);
+			expect(responseMetadata).toContain('_content');
+			expect(responseMetadata).toContain('_headers');
+			expect(responseMetadata).toContain('_rc');
 		});
 
 		test('filehandle', async () => {
@@ -178,5 +203,41 @@ describe('Perl Debug Adapter', () => {
 			expect(evaluate.success).toBe(true);
 			expect(evaluate.body.result).toBe('\\*{"::\\$logfile"}');
 		});
+	});
+});
+
+describe('PerlDebugSession fork handling', () => {
+	let session: any;
+	let events: any[];
+
+	beforeEach(() => {
+		const { PerlDebugSession } = require('../perlDebug');
+		session = new PerlDebugSession();
+		events = [];
+		session.sendEvent = (event: any) => {
+			events.push(event);
+		};
+		session._session = {
+			killed: false,
+			kill: jest.fn(() => true)
+		};
+	});
+
+	test('terminates unsupported forked sessions to avoid corrupted state', () => {
+		session.handleSessionOutput('Forked, but do not know how to create a new TTY', 'stderr');
+
+		expect(session._session.kill).toHaveBeenCalledTimes(1);
+		expect(events.some((event) => event.event === 'terminated')).toBe(true);
+		expect(events.some((event) => event.event === 'output' && event.body.category === 'important' && event.body.output.includes('not supported by this adapter'))).toBe(true);
+	});
+
+	test('forwards normal process output without terminating the session', () => {
+		session.handleSessionOutput('hello from perl\n', 'stdout');
+
+		expect(session._session.kill).not.toHaveBeenCalled();
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe('output');
+		expect(events[0].body.category).toBe('stdout');
+		expect(events[0].body.output).toBe('hello from perl\n');
 	});
 });


### PR DESCRIPTION
## Summary

Merge `release/2.0.0` into `main` with major debugger reliability and variable-inspection improvements.

## Key Changes

- Default transport switched to `socket`; forked runtime handling added.
- Fixed pre-launch breakpoint races and stop-on-entry regressions.
- Added lazy variable loading and chunked array/hash rendering (`maxArrayElements`, `maxHashElements`).
- Improved large-collection behavior (stable chunk expansion, configurable hash ordering via `sortKeys`).
- Hardened `setVariable` for nested/chunked values and repeated edits.
- Added retry cap for variable dumping and better detached process-tree cleanup.

## Issue References

Closes #18  
Closes #26  
Closes #27  
Closes #29  

Relates to #24 